### PR TITLE
Fix task string representation

### DIFF
--- a/task.py
+++ b/task.py
@@ -53,7 +53,9 @@ class Task:
         Returns:
             str: A string representation of the task, including its name and sub-tasks.
         """
-        return self.name +" {" +self.prt_sbtsk() +"}" if self.prt_sbtsk() is not None else self.name
+        if self.sub_tasks:
+            return f"{self.name} {{{self.prt_sbtsk()}}}"
+        return self.name
 
     def add_sub_task(self, task):
         """
@@ -89,10 +91,10 @@ class Task:
         Returns:
             str: A string representation of the sub-tasks of the task.
         """
-        output = ""
+        names = []
         for task in self.sub_tasks:
-            if task.sub_tasks != []:
-                output += " " + task.name + " {" + task.prt_sbtsk() + "}"
+            if task.sub_tasks:
+                names.append(f"{task.name} {{{task.prt_sbtsk()}}}")
             else:
-                output += " " + task.name + ", "
-        return output
+                names.append(task.name)
+        return ", ".join(names)


### PR DESCRIPTION
## Summary
- fix formatting bug in `Task.__str__` and `Task.prt_sbtsk`

## Testing
- `python - <<'PY'
from task import Task
p = Task('P')
p.add_sub_task(Task('A'))
p.add_sub_task(Task('B'))
print(str(p))
PY`

------
https://chatgpt.com/codex/tasks/task_e_68779002f6e4833396b9af1d6290ab69