### PR TITLE
Fix confirm_edit docstring

### DIFF
--- a/window.py
+++ b/window.py
@@ -137,7 +137,7 @@ class Window:
         Confirms the edit of a task and updates the listbox.
 
         Args:
-            task_name_field (tk.StringVar): The variable containing the new task name.
+            task_name_field (tk.Entry): The entry widget containing the new task name.
             selected_index (int): The index of the task being edited.
             confirm_button (tk.Button): The confirm button for editing the task.
         """


### PR DESCRIPTION
## Summary
- update confirm_edit's docstring to reference a tk.Entry

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_687793f72d208333b186392ea6704d7a