### PR TITLE
Add tests and instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ The Task-Manager Application is a simple graphical user interface (GUI) applicat
 - `controller.py`: Defines the `TaskController` class for managing tasks.
 - `window.py`: Defines the `Window` class for creating the main GUI window.
 - `object.pkl`: Pickle file to store tasks.
+## Running Tests
+Run `pytest` from the repository root to execute the test suite.
 
 ## Contributions
 Contributions to this project are welcome. If you find any bugs or have suggestions for improvements, please open an issue or submit a pull request on GitHub.

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -1,0 +1,29 @@
+import os, sys
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+from task import Task
+from controller import TaskController
+
+
+def create_controller():
+    main = Task('Main')
+    return TaskController(main)
+
+
+def test_add_task():
+    c = create_controller()
+    c.add_task('A')
+    assert [t.name for t in c.get_sub_tasks()] == ['A']
+
+
+def test_edit_and_delete_task():
+    c = create_controller()
+    c.add_task('A')
+    c.edit_task(0, 'B')
+    assert c.get_sub_tasks()[0].name == 'B'
+    c.delete_task(0)
+    assert c.get_sub_tasks() == []
+
+
+def test_get_task_name():
+    c = create_controller()
+    assert c.get_task_name() == 'Main'

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -1,0 +1,30 @@
+import os, sys
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+import pytest
+from task import Task
+
+
+def test_task_str_without_subtasks():
+    task = Task('Task1')
+    assert str(task) == 'Task1'
+
+
+def test_add_and_remove_subtask():
+    task = Task('Main')
+    sub = Task('Sub')
+    task.add_sub_task(sub)
+    assert task.get_sub_tasks() == [sub]
+    task.remove_sub_task(sub)
+    assert task.get_sub_tasks() == []
+
+
+def test_prt_sbtsk_and_str_with_subtasks():
+    main = Task('Main')
+    sub1 = Task('Sub1')
+    sub2 = Task('Sub2')
+    sub1.add_sub_task(Task('SubSub'))
+    main.add_sub_task(sub1)
+    main.add_sub_task(sub2)
+    # prt_sbtsk should include nested representation
+    assert main.prt_sbtsk() == 'Sub1 {SubSub}, Sub2'
+    assert str(main) == 'Main {Sub1 {SubSub}, Sub2}'

--- a/tests/test_window.py
+++ b/tests/test_window.py
@@ -1,0 +1,102 @@
+import os, sys
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+from task import Task
+from controller import TaskController
+import window
+
+
+class DummyRoot:
+    def resizable(self, x, y):
+        self.size = (x, y)
+
+
+class DummyStringVar:
+    def __init__(self):
+        self.value = ''
+    def set(self, v):
+        self.value = v
+    def get(self):
+        return self.value
+
+
+class DummyWidget:
+    def __init__(self, *args, **kwargs):
+        self.command = kwargs.get('command')
+    def pack(self):
+        pass
+    def destroy(self):
+        pass
+    def invoke(self):
+        if self.command:
+            self.command()
+
+
+class DummyEntry(DummyWidget):
+    def __init__(self, *args, textvariable=None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.textvariable = textvariable
+    def get(self):
+        return self.textvariable.get() if self.textvariable else ''
+
+
+class DummyListbox(DummyWidget):
+    END = 'end'
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.items = []
+        self.selection = ()
+    def delete(self, start, end):
+        self.items = []
+    def insert(self, index, item):
+        self.items.append(item)
+    def curselection(self):
+        return self.selection
+
+
+class DummyTkModule:
+    END = 'end'
+    Label = DummyWidget
+    Button = DummyWidget
+    Entry = DummyEntry
+    Listbox = DummyListbox
+    StringVar = DummyStringVar
+
+
+def setup_window(monkeypatch):
+    fake_tk = DummyTkModule()
+    monkeypatch.setattr(window, 'tk', fake_tk)
+    root = DummyRoot()
+    controller = TaskController(Task('Main'))
+    return window.Window(root, controller)
+
+
+def test_window_initial_refresh(monkeypatch):
+    win = setup_window(monkeypatch)
+    assert win.listbox.items == []
+    win.controller.add_task('Task1')
+    win.refresh_window()
+    assert win.listbox.items == ['Task1']
+
+
+def test_create_task_button(monkeypatch):
+    win = setup_window(monkeypatch)
+    entry = DummyEntry(textvariable=DummyStringVar())
+    entry.textvariable.set('New')
+    btn = DummyWidget()
+    win.create_task_button(entry, btn)
+    assert [t.name for t in win.controller.get_sub_tasks()] == ['New']
+    assert win.listbox.items == ['New']
+
+
+def test_confirm_edit(monkeypatch):
+    win = setup_window(monkeypatch)
+    win.controller.add_task('Old')
+    win.refresh_window()
+    var = DummyStringVar()
+    var.set('Updated')
+    win.listbox.selection = (0,)
+    entry = DummyEntry(textvariable=var)
+    btn = DummyWidget()
+    win.confirm_edit(entry, (0,), btn)
+    assert win.controller.get_sub_tasks()[0].name == 'Updated'
+


### PR DESCRIPTION
## Summary
- add pytest-based tests for `Task`, `TaskController`, and `Window`
- document how to run the tests in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687793fcb2f08333a74bb2b95046dd0f