### PR TITLE
Add priority sorting to UI

### DIFF
--- a/controller.py
+++ b/controller.py
@@ -24,6 +24,7 @@ class TaskController:
         delete_task: Deletes a task at the specified index.
         get_task_name: Returns the name of the task.
         get_sub_tasks: Returns the list of sub-tasks associated with the task.
+        sort_tasks_by_priority: Sort tasks by their priority value.
     """
 
     def __init__(self, task):
@@ -98,3 +99,7 @@ class TaskController:
             list of Task: The list of sub-tasks associated with the task.
         """
         return self.task.get_sub_tasks()
+
+    def sort_tasks_by_priority(self):
+        """Sort the controller's sub tasks by priority (None values last)."""
+        self.task.sub_tasks.sort(key=lambda t: (t.priority is None, t.priority))

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -39,3 +39,12 @@ def test_add_task_with_extras_and_completion():
     assert c.get_sub_tasks()[0].completed
     c.mark_task_incomplete(0)
     assert not c.get_sub_tasks()[0].completed
+
+
+def test_sort_tasks_by_priority():
+    c = create_controller()
+    c.add_task('Low', priority=5)
+    c.add_task('High', priority=1)
+    c.add_task('None')
+    c.sort_tasks_by_priority()
+    assert [t.name for t in c.get_sub_tasks()] == ['High', 'Low', 'None']

--- a/tests/test_window.py
+++ b/tests/test_window.py
@@ -143,3 +143,13 @@ def test_confirm_edit(monkeypatch):
     assert t.priority == 3
     assert t.completed
 
+
+def test_sort_button(monkeypatch):
+    win = setup_window(monkeypatch)
+    win.controller.add_task('Low', priority=5)
+    win.controller.add_task('High', priority=1)
+    win.controller.add_task('None')
+    win.sort_tasks_by_priority()
+    assert [t.name for t in win.controller.get_sub_tasks()] == ['High', 'Low', 'None']
+    assert [item.split()[0] for item in win.listbox.items] == ['High', 'Low', 'None']
+

--- a/window.py
+++ b/window.py
@@ -50,6 +50,9 @@ class Window:
         add_task_button = tk.Button(self.root, text="Add Task", command= self.add_task)
         add_task_button.pack()
 
+        sort_btn = tk.Button(self.root, text="Sort by Priority", command=self.sort_tasks_by_priority)
+        sort_btn.pack()
+
         self.listbox = tk.Listbox(self.root)
         self.listbox.pack()
 
@@ -239,6 +242,11 @@ class Window:
             self.controller.mark_task_completed(idx)
         else:
             self.controller.mark_task_incomplete(idx)
+        self.refresh_window()
+
+    def sort_tasks_by_priority(self):
+        """Sort tasks by priority using the controller and refresh the view."""
+        self.controller.sort_tasks_by_priority()
         self.refresh_window()
 
     def refresh_window(self):


### PR DESCRIPTION
## Summary
- allow sorting tasks by priority through the controller
- expose sort action in the GUI
- test priority sorting

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877e8a58b00833399193e9755282b06