### PR TITLE
Add double click to open subtasks

### DIFF
--- a/window.py
+++ b/window.py
@@ -55,6 +55,8 @@ class Window:
 
         self.listbox = tk.Listbox(self.root)
         self.listbox.pack()
+        # Bind double-click on a task to open its subtasks
+        self.listbox.bind("<Double-Button-1>", lambda e: self.view_subtasks())
 
         view_subtasks_btn = tk.Button(self.root, text="View Subtasks", command= self.view_subtasks)
         view_subtasks_btn.pack()


### PR DESCRIPTION
## Summary
- bind `<Double-Button-1>` on the task list to call `view_subtasks`
- update test stubs to store Listbox bindings
- add regression test for double click behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877ec23335883339e829084ae3dd5c8