### PR TITLE
Add sorting by due date

### DIFF
--- a/controller.py
+++ b/controller.py
@@ -103,3 +103,7 @@ class TaskController:
     def sort_tasks_by_priority(self):
         """Sort the controller's sub tasks by priority (None values last)."""
         self.task.sub_tasks.sort(key=lambda t: (t.priority is None, t.priority))
+
+    def sort_tasks_by_due_date(self):
+        """Sort the controller's sub tasks by due date (None values last)."""
+        self.task.sub_tasks.sort(key=lambda t: (t.due_date is None, t.due_date))

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -48,3 +48,12 @@ def test_sort_tasks_by_priority():
     c.add_task('None')
     c.sort_tasks_by_priority()
     assert [t.name for t in c.get_sub_tasks()] == ['High', 'Low', 'None']
+
+
+def test_sort_tasks_by_due_date():
+    c = create_controller()
+    c.add_task('Later', due_date='2025-01-01')
+    c.add_task('Sooner', due_date='2024-01-01')
+    c.add_task('NoDue')
+    c.sort_tasks_by_due_date()
+    assert [t.name for t in c.get_sub_tasks()] == ['Sooner', 'Later', 'NoDue']

--- a/tests/test_window.py
+++ b/tests/test_window.py
@@ -207,6 +207,16 @@ def test_sort_button(monkeypatch):
     assert [item.split()[0] for item in win.listbox.items] == ['High', 'Low', 'None']
 
 
+def test_sort_by_due_date(monkeypatch):
+    win = setup_window(monkeypatch)
+    win.controller.add_task('Later', due_date='2025-01-01')
+    win.controller.add_task('Sooner', due_date='2024-01-01')
+    win.controller.add_task('NoDue')
+    win.sort_tasks_by_due_date()
+    assert [t.name for t in win.controller.get_sub_tasks()] == ['Sooner', 'Later', 'NoDue']
+    assert [item.split()[0] for item in win.listbox.items] == ['Sooner', 'Later', 'NoDue']
+
+
 def test_double_click_opens_subtasks(monkeypatch):
     called = {}
 

--- a/window.py
+++ b/window.py
@@ -53,6 +53,9 @@ class Window:
         sort_btn = tk.Button(self.root, text="Sort by Priority", command=self.sort_tasks_by_priority)
         sort_btn.pack()
 
+        sort_due_btn = tk.Button(self.root, text="Sort by Due Date", command=self.sort_tasks_by_due_date)
+        sort_due_btn.pack()
+
         self.listbox = tk.Listbox(self.root)
         self.listbox.pack()
         # Bind double-click on a task to open its subtasks
@@ -253,6 +256,11 @@ class Window:
     def sort_tasks_by_priority(self):
         """Sort tasks by priority using the controller and refresh the view."""
         self.controller.sort_tasks_by_priority()
+        self.refresh_window()
+
+    def sort_tasks_by_due_date(self):
+        """Sort tasks by due date using the controller and refresh the view."""
+        self.controller.sort_tasks_by_due_date()
         self.refresh_window()
 
     def refresh_window(self):


### PR DESCRIPTION
## Summary
- support sorting tasks by due date in `TaskController`
- add `Sort by Due Date` button and handler in `Window`
- test due date sorting in controller and window modules

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877fe9c41a08333a359a66f9def9dfa