### PR TITLE
Use Toplevel for subtask windows

### DIFF
--- a/tests/test_window.py
+++ b/tests/test_window.py
@@ -233,3 +233,37 @@ def test_double_click_opens_subtasks(monkeypatch):
     bound(None)
     assert called.get('view')
 
+
+def test_view_subtasks_uses_toplevel(monkeypatch):
+    created = {}
+
+    class FakeTk(DummyTkModule):
+        pass
+
+    fake_tk = FakeTk()
+
+    def toplevel(parent=None):
+        created['parent'] = parent
+        return DummyRoot()
+
+    fake_tk.Toplevel = toplevel
+
+    def fake_tk_root(*args, **kwargs):
+        created['tk_called'] = True
+        return DummyRoot()
+
+    fake_tk.Tk = fake_tk_root
+
+    monkeypatch.setattr(window, 'tk', fake_tk)
+
+    root = DummyRoot()
+    controller = TaskController(Task('Main'))
+    controller.add_task('Sub')
+    win = window.Window(root, controller)
+    win.listbox.selection = (0,)
+
+    win.view_subtasks()
+
+    assert created.get('parent') is root
+    assert 'tk_called' not in created
+

--- a/window.py
+++ b/window.py
@@ -82,7 +82,7 @@ class Window:
             return
 
         selected_task = self.controller.get_sub_tasks()[selected_index[0]]
-        r = tk.Tk()
+        r = tk.Toplevel(self.root)
         Window(r, TaskController(selected_task))
 
     def delete_task(self):


### PR DESCRIPTION
## Summary
- open new subtask windows with `tk.Toplevel`
- verify subtask windows use the existing root
- test new subtask window behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687804ecb3e48333ae5c3167322279c1