### PR TITLE
Add calendar due date widget

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 # Tkinter is included with Python on most platforms.
 # On some Linux distributions you may need to install python3-tk via your package manager.
 pytest
+tkcalendar

--- a/tests/test_window.py
+++ b/tests/test_window.py
@@ -115,6 +115,7 @@ def setup_window(monkeypatch):
     fake_tk = DummyTkModule()
     monkeypatch.setattr(window, 'tk', fake_tk)
     monkeypatch.setattr(window, 'ttk', fake_tk)
+    monkeypatch.setattr(window, 'DateEntry', DummyEntry)
     root = DummyRoot()
     controller = TaskController(Task('Main'))
     return window.Window(root, controller)
@@ -195,6 +196,7 @@ def test_edit_task_prefills_fields(monkeypatch):
     fake_tk.Entry = TrackedEntry
     monkeypatch.setattr(window, 'tk', fake_tk)
     monkeypatch.setattr(window, 'ttk', fake_tk)
+    monkeypatch.setattr(window, 'DateEntry', TrackedEntry)
     root = DummyRoot()
     controller = TaskController(Task('Main'))
     controller.add_task('Existing', due_date='2024-12-31', priority=2)
@@ -219,6 +221,7 @@ def test_edit_subtask_prefills_fields(monkeypatch):
     fake_tk.Entry = TrackEntry
     monkeypatch.setattr(window, 'tk', fake_tk)
     monkeypatch.setattr(window, 'ttk', fake_tk)
+    monkeypatch.setattr(window, 'DateEntry', TrackEntry)
     root = DummyRoot()
     controller = TaskController(Task('Main'))
     parent = Task('Parent')

--- a/window.py
+++ b/window.py
@@ -10,6 +10,10 @@ Usage:
 
 import tkinter as tk
 import tkinter.ttk as ttk
+try:
+    from tkcalendar import DateEntry
+except ModuleNotFoundError:  # Fallback when tkcalendar is unavailable
+    DateEntry = ttk.Entry
 
 if not hasattr(ttk, "Listbox"):
     ttk.Listbox = tk.Listbox
@@ -141,7 +145,7 @@ class Window:
         task_entry = ttk.Entry(form, textvariable=task_name_field)
         task_entry.grid(row=0, column=1)
         ttk.Label(form, text="Due Date:").grid(row=1, column=0, sticky="e")
-        due_date_entry = ttk.Entry(form, textvariable=due_date_field)
+        due_date_entry = DateEntry(form, textvariable=due_date_field)
         due_date_entry.grid(row=1, column=1)
         ttk.Label(form, text="Priority:").grid(row=2, column=0, sticky="e")
         priority_entry = ttk.Entry(form, textvariable=priority_field)
@@ -231,7 +235,7 @@ class Window:
         task_entry = ttk.Entry(form, textvariable=task_name_field)
         task_entry.grid(row=0, column=1)
         ttk.Label(form, text="Due Date:").grid(row=1, column=0, sticky="e")
-        due_date_entry = ttk.Entry(form, textvariable=due_date_field)
+        due_date_entry = DateEntry(form, textvariable=due_date_field)
         due_date_entry.grid(row=1, column=1)
         ttk.Label(form, text="Priority:").grid(row=2, column=0, sticky="e")
         priority_entry = ttk.Entry(form, textvariable=priority_field)


### PR DESCRIPTION
## Summary
- use `DateEntry` from tkcalendar for due date fields
- ensure fallback to text entry if tkcalendar isn't installed
- update unit tests to patch DateEntry
- document tkcalendar in requirements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68781a474d6483338ad4ad34932b9db0