### PR TITLE
Add simple fallback calendar

### DIFF
--- a/window.py
+++ b/window.py
@@ -10,10 +10,103 @@ Usage:
 
 import tkinter as tk
 import tkinter.ttk as ttk
+import calendar as _calendar
+import datetime as _datetime
+
 try:
     from tkcalendar import DateEntry
 except ModuleNotFoundError:  # Fallback when tkcalendar is unavailable
-    DateEntry = ttk.Entry
+    class _SimpleCalendar(ttk.Frame):
+        """Very small calendar widget with month navigation."""
+
+        def __init__(self, master, variable, close_cb):
+            super().__init__(master)
+            self._var = variable
+            self._close_cb = close_cb
+            today = _datetime.date.today()
+            self._year = today.year
+            self._month = today.month
+
+            # Header with navigation
+            header = ttk.Frame(self)
+            header.grid(row=0, column=0, columnspan=7)
+            ttk.Button(header, text="<", command=self._prev_month).grid(row=0, column=0)
+            self._title = ttk.Label(header)
+            self._title.grid(row=0, column=1, columnspan=5)
+            ttk.Button(header, text=">", command=self._next_month).grid(row=0, column=6)
+
+            self._days = ttk.Frame(self)
+            self._days.grid(row=1, column=0, columnspan=7)
+            self._build_days()
+
+        def _build_days(self):
+            for w in self._days.winfo_children():
+                w.destroy()
+
+            self._title.config(text=f"{_calendar.month_name[self._month]} {self._year}")
+            for i, name in enumerate(["Mo", "Tu", "We", "Th", "Fr", "Sa", "Su"]):
+                ttk.Label(self._days, text=name).grid(row=0, column=i)
+
+            cal = _calendar.Calendar()
+            row = 1
+            for week in cal.monthdayscalendar(self._year, self._month):
+                for col, day in enumerate(week):
+                    if day == 0:
+                        ttk.Label(self._days, text="").grid(row=row, column=col)
+                    else:
+                        btn = ttk.Button(
+                            self._days,
+                            text=str(day),
+                            width=2,
+                            command=lambda d=day: self._select_day(d),
+                        )
+                        btn.grid(row=row, column=col)
+                row += 1
+
+        def _select_day(self, day):
+            self._var.set(f"{self._year:04d}-{self._month:02d}-{day:02d}")
+            self._close_cb()
+
+        def _prev_month(self):
+            if self._month == 1:
+                self._month = 12
+                self._year -= 1
+            else:
+                self._month -= 1
+            self._build_days()
+
+        def _next_month(self):
+            if self._month == 12:
+                self._month = 1
+                self._year += 1
+            else:
+                self._month += 1
+            self._build_days()
+
+    class DateEntry(ttk.Entry):
+        """Fallback DateEntry showing a popup calendar."""
+
+        def __init__(self, master=None, textvariable=None, **kwargs):
+            self._var = textvariable or tk.StringVar()
+            super().__init__(master, textvariable=self._var, **kwargs)
+            self._popup = None
+            self.bind("<Button-1>", self._open_popup)
+
+        def _open_popup(self, event=None):
+            if self._popup:
+                return
+            self._popup = tk.Toplevel(self)
+            self._popup.wm_overrideredirect(True)
+            cal = _SimpleCalendar(self._popup, self._var, self._close_popup)
+            cal.pack()
+            x = self.winfo_rootx()
+            y = self.winfo_rooty() + self.winfo_height()
+            self._popup.geometry(f"+{x}+{y}")
+
+        def _close_popup(self):
+            if self._popup is not None:
+                self._popup.destroy()
+                self._popup = None
 
 if not hasattr(ttk, "Listbox"):
     ttk.Listbox = tk.Listbox

--- a/window.py
+++ b/window.py
@@ -96,7 +96,8 @@ except ModuleNotFoundError:  # Fallback when tkcalendar is unavailable
             if self._popup:
                 return
             self._popup = tk.Toplevel(self)
-            self._popup.wm_overrideredirect(True)
+            self._popup.transient(self)
+            self._popup.protocol("WM_DELETE_WINDOW", self._close_popup)
             cal = _SimpleCalendar(self._popup, self._var, self._close_popup)
             cal.pack()
             x = self.winfo_rootx()
@@ -231,6 +232,13 @@ class Window:
         priority_field = tk.StringVar()
         completed_var = tk.IntVar()
 
+        # Keep a reference on the dialog so these vars aren't garbage collected
+        # while the window is open
+        dialog.task_name_var = task_name_field
+        dialog.due_date_var = due_date_field
+        dialog.priority_var = priority_field
+        dialog.completed_var = completed_var
+
         form = ttk.Frame(dialog)
         form.grid(row=0, column=0, padx=10, pady=10)
 
@@ -313,6 +321,12 @@ class Window:
         due_date_field = tk.StringVar()
         priority_field = tk.StringVar()
         completed_var = tk.IntVar()
+        # Keep a reference on the dialog so these vars aren't garbage collected
+        # while the window is open
+        dialog.task_name_var = task_name_field
+        dialog.due_date_var = due_date_field
+        dialog.priority_var = priority_field
+        dialog.completed_var = completed_var
 
         task_name_field.set(task.name)
         if task.due_date:


### PR DESCRIPTION
## Summary
- add a basic popup calendar when tkcalendar isn't installed
- allow month navigation in the fallback calendar

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687826daa8f08333b52e04c9e5af65bb