### PR TITLE
Add theme support to Window

### DIFF
--- a/orga.py
+++ b/orga.py
@@ -61,7 +61,9 @@ def on_closing(task, rt):
 
 
 if __name__ == "__main__":
+
     root = tk.Tk()
+    root.title("Task Manager")
 
     main_tasks = load_tasks()
 

--- a/tests/test_window.py
+++ b/tests/test_window.py
@@ -94,6 +94,17 @@ class DummyFrame(DummyWidget):
     pass
 
 
+class DummyStyle:
+    def __init__(self, root=None):
+        self.root = root
+        self.used = None
+
+    def theme_use(self, name=None):
+        if name is not None:
+            self.used = name
+        return self.used
+
+
 class DummyTkModule:
     END = 'end'
     Label = DummyWidget
@@ -105,6 +116,7 @@ class DummyTkModule:
     IntVar = DummyIntVar
     Checkbutton = DummyCheckbutton
     Frame = DummyFrame
+    Style = DummyStyle
 
     @staticmethod
     def Toplevel(parent=None):

--- a/window.py
+++ b/window.py
@@ -148,6 +148,14 @@ class Window:
         self.controller = controller
         self.name = controller.get_task_name()
 
+        # Configure ttk theme for a more modern look
+        self.style = ttk.Style(self.root)
+        try:
+            self.style.theme_use("clam")
+        except Exception:
+            # Fallback silently if theme is unavailable
+            pass
+
         # Optional file menu for JSON import/export when available
         if hasattr(tk, "Menu") and hasattr(self.root, "config"):
             menubar = tk.Menu(self.root)
@@ -476,3 +484,10 @@ class Window:
                 if getattr(task, "priority", None) is not None:
                     display += f" - Priority: {task.priority}"
                 self.listbox.insert(tk.END, display)
+
+    def use_theme(self, theme_name):
+        """Change the ttk theme for this window."""
+        try:
+            self.style.theme_use(theme_name)
+        except Exception:
+            pass


### PR DESCRIPTION
## Summary
- configure ttk styles inside `Window.__init__` using the *clam* theme
- expose a `use_theme` method to change themes at runtime
- extend window tests with a `DummyStyle` implementation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68783601b2308333b99adfa90c8aab55