### PR TITLE
Add priority-based list colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,14 @@ The Task-Manager Application is a simple graphical user interface (GUI) applicat
 - Optional due dates and priority levels for tasks
 - Mark tasks as completed
 
+## Color Coding
+The task list uses colors to highlight different states and priorities:
+
+- **Gray**: completed tasks
+- **Red**: tasks past their due date
+- **Orange**: priority `1` tasks
+- **Yellow**: priority `2` tasks
+
 ## Requirements
 - Python 3.7
 - Tkinter (should be included with Python installation; on some Linux

--- a/tests/test_window.py
+++ b/tests/test_window.py
@@ -424,3 +424,12 @@ def test_overdue_task_red(monkeypatch):
     win.refresh_window()
     assert win.listbox.itemconfigs.get(0, {}).get('fg') == 'red'
 
+
+def test_priority_colors(monkeypatch):
+    win = setup_window(monkeypatch)
+    win.controller.add_task('High', priority=1)
+    win.controller.add_task('Medium', priority=2)
+    win.refresh_window()
+    assert win.listbox.itemconfigs.get(0, {}).get('fg') == 'orange'
+    assert win.listbox.itemconfigs.get(1, {}).get('fg') == 'yellow'
+

--- a/window.py
+++ b/window.py
@@ -533,6 +533,12 @@ class Window:
                 except ValueError:
                     pass
 
+            # Priority based color overrides completion/due date colors
+            priority_colors = {1: "orange", 2: "yellow"}
+            prio = getattr(task, "priority", None)
+            if prio in priority_colors:
+                color = priority_colors[prio]
+
             self.listbox.itemconfig(idx, fg=color)
             idx += 1
 


### PR DESCRIPTION
## Summary
- refresh the window with color highlighting for priority 1 & 2
- document new colour mapping in the README
- test that list items get the correct colours for each priority level

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68783e7cdf6c8333ab72a4162f048605