### PR TITLE
Add advanced filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,11 @@ The Task-Manager Application is a simple graphical user interface (GUI) applicat
 
 5. **Saving Changes**: The application prompts you to save changes when you close the window. Click "Yes" to save changes or "No" to discard them.
 
+6. **Filtering Tasks**: Use the controls below the task list to filter. You can
+   search by name, hide completed tasks, show only tasks due before or after a
+   specific date, and display tasks with priority above or below a chosen
+   threshold. Click "Apply Filter" to update the list.
+
 ## File Structure
 - `orga.py`: Main entry point of the application.
 - `task.py`: Defines the `Task` class representing a single task.

--- a/tests/test_window.py
+++ b/tests/test_window.py
@@ -132,7 +132,6 @@ def setup_window(monkeypatch):
     monkeypatch.setattr(window, 'tk', fake_tk)
     monkeypatch.setattr(window, 'ttk', fake_tk)
     monkeypatch.setattr(window, 'DateEntry', DummyEntry)
-    monkeypatch.setattr(window, 'DateEntry', DummyEntry)
     root = DummyRoot()
     controller = TaskController(Task('Main'))
     return window.Window(root, controller)

--- a/tests/test_window.py
+++ b/tests/test_window.py
@@ -132,6 +132,7 @@ def setup_window(monkeypatch):
     monkeypatch.setattr(window, 'tk', fake_tk)
     monkeypatch.setattr(window, 'ttk', fake_tk)
     monkeypatch.setattr(window, 'DateEntry', DummyEntry)
+    monkeypatch.setattr(window, 'DateEntry', DummyEntry)
     root = DummyRoot()
     controller = TaskController(Task('Main'))
     return window.Window(root, controller)
@@ -396,6 +397,7 @@ def test_view_subtasks_uses_toplevel(monkeypatch):
 
     monkeypatch.setattr(window, 'tk', fake_tk)
     monkeypatch.setattr(window, 'ttk', fake_tk)
+    monkeypatch.setattr(window, 'DateEntry', DummyEntry)
 
     root = DummyRoot()
     controller = TaskController(Task('Main'))
@@ -423,4 +425,44 @@ def test_overdue_task_red(monkeypatch):
     win.controller.add_task('Late', due_date=past)
     win.refresh_window()
     assert win.listbox.itemconfigs.get(0, {}).get('fg') == 'red'
+
+
+def test_due_date_filter_before(monkeypatch):
+    win = setup_window(monkeypatch)
+    win.controller.add_task('Soon', due_date='2024-01-01')
+    win.controller.add_task('Later', due_date='2026-01-01')
+    win.due_filter_var.set('2025-01-01')
+    win.due_before_var.set(1)
+    win.refresh_window()
+    assert [item.split()[0] for item in win.listbox.items] == ['Soon']
+
+
+def test_due_date_filter_after(monkeypatch):
+    win = setup_window(monkeypatch)
+    win.controller.add_task('Soon', due_date='2024-01-01')
+    win.controller.add_task('Later', due_date='2026-01-01')
+    win.due_filter_var.set('2025-01-01')
+    win.due_after_var.set(1)
+    win.refresh_window()
+    assert [item.split()[0] for item in win.listbox.items] == ['Later']
+
+
+def test_priority_filter_above(monkeypatch):
+    win = setup_window(monkeypatch)
+    win.controller.add_task('Low', priority=5)
+    win.controller.add_task('High', priority=1)
+    win.priority_filter_var.set('2')
+    win.priority_above_var.set(1)
+    win.refresh_window()
+    assert [item.split()[0] for item in win.listbox.items] == ['Low']
+
+
+def test_priority_filter_below(monkeypatch):
+    win = setup_window(monkeypatch)
+    win.controller.add_task('Low', priority=5)
+    win.controller.add_task('High', priority=1)
+    win.priority_filter_var.set('3')
+    win.priority_below_var.set(1)
+    win.refresh_window()
+    assert [item.split()[0] for item in win.listbox.items] == ['High']
 


### PR DESCRIPTION
## Summary
- extend README with description of new filtering options
- add due date and priority filter controls to GUI
- filter tasks in `refresh_window`
- test filtering behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68783e8279c48333816b110c60866a04