### PR TITLE
Add priority-based color logic

### DIFF
--- a/tests/test_window.py
+++ b/tests/test_window.py
@@ -469,6 +469,19 @@ def test_priority_colors(monkeypatch):
     win.controller.add_task('High', priority=1)
     win.controller.add_task('Medium', priority=2)
     win.refresh_window()
-    assert win.listbox.itemconfigs.get(0, {}).get('fg') == 'orange'
-    assert win.listbox.itemconfigs.get(1, {}).get('fg') == 'yellow'
+    assert win.listbox.itemconfigs.get(0, {}).get('fg') == 'red'
+    assert win.listbox.itemconfigs.get(1, {}).get('fg') == 'orange'
+
+
+def test_priority_completed_overdue_coexist(monkeypatch):
+    win = setup_window(monkeypatch)
+    past = (datetime.date.today() - datetime.timedelta(days=1)).isoformat()
+    win.controller.add_task('DoneHigh', priority=1)
+    win.controller.mark_task_completed(0)
+    win.controller.add_task('OverdueMedium', due_date=past, priority=2)
+    win.refresh_window()
+    # Completed task should remain gray despite priority
+    assert win.listbox.itemconfigs.get(0, {}).get('fg') == 'gray'
+    # Overdue task should be red despite medium priority
+    assert win.listbox.itemconfigs.get(1, {}).get('fg') == 'red'
 

--- a/window.py
+++ b/window.py
@@ -609,11 +609,13 @@ class Window:
                 except ValueError:
                     pass
 
-            # Priority based color overrides completion/due date colors
-            priority_colors = {1: "orange", 2: "yellow"}
+            # Priority based color should coexist with completion/overdue logic
             prio = getattr(task, "priority", None)
-            if prio in priority_colors:
-                color = priority_colors[prio]
+            if not task.completed:
+                if prio == 1:
+                    color = "red"
+                elif prio == 2 and color != "red":
+                    color = "orange"
 
             self.listbox.itemconfig(idx, fg=color)
             idx += 1


### PR DESCRIPTION
## Summary
- highlight task priorities in `window.refresh_window` using red for high and orange for medium
- keep priority coloring compatible with completed and overdue states
- update and extend tests for new color rules

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878430e0d508333945562a9c4475525