### PR TITLE
Add JSON error handling test

### DIFF
--- a/persistence.py
+++ b/persistence.py
@@ -9,7 +9,14 @@ def save_tasks_to_json(task, path):
 
 
 def load_tasks_from_json(path):
-    """Load tasks from a JSON file at ``path`` and return a ``Task``."""
-    with open(path, "r", encoding="utf-8") as fh:
-        data = json.load(fh)
-    return Task.from_dict(data)
+    """Load tasks from a JSON file at ``path`` and return a ``Task``.
+
+    If the file cannot be read or contains invalid JSON, a new ``Task('Main')``
+    is returned instead of raising an exception.
+    """
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+        return Task.from_dict(data)
+    except (FileNotFoundError, json.JSONDecodeError, OSError, TypeError):
+        return Task("Main")

--- a/tests/test_json_persistence.py
+++ b/tests/test_json_persistence.py
@@ -1,4 +1,5 @@
 import os, sys
+import pytest
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 from task import Task
 from persistence import save_tasks_to_json, load_tasks_from_json
@@ -28,4 +29,17 @@ def test_json_round_trip_optional_fields(tmp_path):
     save_tasks_to_json(task, path)
     loaded = load_tasks_from_json(path)
     assert loaded.to_dict() == task.to_dict()
+
+
+def test_load_tasks_with_invalid_json(tmp_path):
+    bad_path = tmp_path / 'bad.json'
+    bad_path.write_text('{ invalid json', encoding='utf-8')
+
+    try:
+        task = load_tasks_from_json(bad_path)
+    except Exception as exc:
+        pytest.fail(f"Exception propagated: {exc}")
+
+    assert isinstance(task, Task)
+    assert task.name == 'Main'
 


### PR DESCRIPTION
## Summary
- handle invalid JSON when loading tasks
- add regression test for error handling in JSON persistence

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878441831f483339fc851613d87d200