### PR TITLE
Handle invalid priority input

### DIFF
--- a/tests/test_window.py
+++ b/tests/test_window.py
@@ -204,6 +204,26 @@ def test_create_task_button(monkeypatch):
     assert win.listbox.items == ['New (Completed) - Due: 2025-12-31 - Priority: 2']
 
 
+def test_create_task_button_invalid_priority(monkeypatch):
+    win = setup_window(monkeypatch)
+    warnings = []
+    monkeypatch.setattr(window.tkMessageBox, 'showwarning', lambda *a, **k: warnings.append(True))
+    entry = DummyEntry(textvariable=DummyStringVar())
+    due = DummyEntry(textvariable=DummyStringVar())
+    prio = DummyEntry(textvariable=DummyStringVar())
+    chk_var = DummyIntVar()
+    chk = DummyCheckbutton(variable=chk_var)
+    entry.textvariable.set('New')
+    due.textvariable.set('2025-12-31')
+    prio.textvariable.set('bad')
+    chk_var.set(0)
+    btn = DummyWidget()
+    win.create_task_button(entry, due, prio, chk_var, chk, btn)
+    t = win.controller.get_sub_tasks()[0]
+    assert t.priority is None
+    assert warnings
+
+
 def test_confirm_edit(monkeypatch):
     win = setup_window(monkeypatch)
     win.controller.add_task('Old')
@@ -228,6 +248,28 @@ def test_confirm_edit(monkeypatch):
     assert t.due_date == '2026-01-01'
     assert t.priority == 3
     assert t.completed
+
+
+def test_confirm_edit_invalid_priority(monkeypatch):
+    win = setup_window(monkeypatch)
+    win.controller.add_task('Old')
+    win.refresh_window()
+    warnings = []
+    monkeypatch.setattr(window.tkMessageBox, 'showwarning', lambda *a, **k: warnings.append(True))
+    var = DummyStringVar(); var.set('Updated')
+    due_var = DummyStringVar(); due_var.set('2026-01-01')
+    prio_var = DummyStringVar(); prio_var.set('bad')
+    chk_var = DummyIntVar(); chk_var.set(0)
+    win.listbox.selection = (0,)
+    entry = DummyEntry(textvariable=var)
+    due_entry = DummyEntry(textvariable=due_var)
+    prio_entry = DummyEntry(textvariable=prio_var)
+    chk = DummyCheckbutton(variable=chk_var)
+    btn = DummyWidget()
+    win.confirm_edit(entry, due_entry, prio_entry, chk_var, chk, (0,), btn)
+    t = win.controller.get_sub_tasks()[0]
+    assert t.priority is None
+    assert warnings
 
 
 def test_edit_task_prefills_fields(monkeypatch):

--- a/window.py
+++ b/window.py
@@ -10,6 +10,7 @@ Usage:
 
 import tkinter as tk
 import tkinter.ttk as ttk
+from tkinter import messagebox as tkMessageBox
 
 import calendar as _calendar
 import datetime as _datetime
@@ -380,7 +381,16 @@ class Window:
         task_name = task_entry.get()
         due_date = due_date_entry.get()
         priority_text = priority_entry.get()
-        priority = int(priority_text) if priority_text else None
+        try:
+            priority = int(priority_text) if priority_text else None
+        except ValueError:
+            priority = None
+            try:
+                tkMessageBox.showwarning(
+                    "Invalid Priority", "Priority must be an integer."
+                )
+            except Exception:
+                pass
         completed = bool(completed_var.get())
 
         task_entry.destroy()
@@ -479,7 +489,16 @@ class Window:
         new_name = task_name_field.get()
         new_due = due_date_entry.get()
         priority_text = priority_entry.get()
-        new_priority = int(priority_text) if priority_text else None
+        try:
+            new_priority = int(priority_text) if priority_text else None
+        except ValueError:
+            new_priority = None
+            try:
+                tkMessageBox.showwarning(
+                    "Invalid Priority", "Priority must be an integer."
+                )
+            except Exception:
+                pass
         completed = bool(completed_var.get())
 
         task_name_field.destroy()


### PR DESCRIPTION
## Summary
- show a warning when priority conversion fails
- treat failed priority as `None`
- test invalid priority input for `create_task_button` and `confirm_edit`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878441bf7848333a2cc5e13713d59c2