### PR TITLE
Fix bootstrap style initialization

### DIFF
--- a/window.py
+++ b/window.py
@@ -161,7 +161,7 @@ class Window:
         # Configure ttk theme for a more modern look
         if BootstrapStyle is not None:
             try:
-                self.style = BootstrapStyle(self.root)
+                self.style = BootstrapStyle(master=self.root)
                 self.style.theme_use("flatly")
             except Exception:
                 # Fallback to regular ttk in case of errors


### PR DESCRIPTION
## Summary
- ensure ttkbootstrap uses the window as master when styling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878d675c05c8333bd58df079c2e65b9