### PR TITLE
Switch persistence to logging warnings

### DIFF
--- a/persistence.py
+++ b/persistence.py
@@ -1,5 +1,9 @@
 import json
+import logging
 from task import Task
+
+
+logger = logging.getLogger(__name__)
 
 
 def save_tasks_to_json(task, path):
@@ -20,5 +24,5 @@ def load_tasks_from_json(path):
             data = json.load(fh)
         return Task.from_dict(data)
     except (FileNotFoundError, json.JSONDecodeError, OSError, TypeError) as err:
-        print(f"Warning: Failed to load tasks from {path}: {err}")
+        logger.warning("Failed to load tasks from %s: %s", path, err)
         return Task("Main")

--- a/tests/test_json_persistence.py
+++ b/tests/test_json_persistence.py
@@ -1,5 +1,6 @@
 import os, sys
 import pytest
+import logging
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 from task import Task
 from persistence import save_tasks_to_json, load_tasks_from_json
@@ -30,23 +31,23 @@ def test_json_round_trip_optional_fields(tmp_path):
     loaded = load_tasks_from_json(path)
     assert loaded.to_dict() == task.to_dict()
 
-def test_load_tasks_missing_file(tmp_path, capsys):
+def test_load_tasks_missing_file(tmp_path, caplog):
     path = tmp_path / 'missing.json'
-    task = load_tasks_from_json(path)
+    with caplog.at_level(logging.WARNING):
+        task = load_tasks_from_json(path)
     assert isinstance(task, Task)
     assert task.name == 'Main'
-    captured = capsys.readouterr()
-    assert 'Warning:' in captured.out
+    assert any('Failed to load tasks' in rec.getMessage() for rec in caplog.records)
 
 
-def test_load_tasks_invalid_json(tmp_path, capsys):
+def test_load_tasks_invalid_json(tmp_path, caplog):
     path = tmp_path / 'bad.json'
     path.write_text('{ invalid json', encoding='utf-8')
-    task = load_tasks_from_json(path)
+    with caplog.at_level(logging.WARNING):
+        task = load_tasks_from_json(path)
     assert isinstance(task, Task)
     assert task.name == 'Main'
-    captured = capsys.readouterr()
-    assert 'Warning:' in captured.out
+    assert any('Failed to load tasks' in rec.getMessage() for rec in caplog.records)
 
 def test_load_tasks_with_invalid_json(tmp_path):
     bad_path = tmp_path / 'bad.json'


### PR DESCRIPTION
## Summary
- replace print warnings with logging in `persistence.py`
- adjust JSON persistence tests to capture logging warnings

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878e9c3d8e48333b0c0982621d3520d