### PR TITLE
Use JSON persistence for orga

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,6 +124,6 @@ cython_debug/
 # VS Code
 .vscode/
 
-# Task Manager pickle file
-object.pkl
+# Task Manager data file
+tasks.json
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The Task-Manager Application is a simple graphical user interface (GUI) applicat
 - Create, edit, and delete tasks
 - View subtasks
 - Add subtasks to a task
-- Save tasks to a file for later retrieval
+- Save tasks to a JSON file for later retrieval
 - Optional due dates and priority levels for tasks
 - Mark tasks as completed
 - Switch themes from the View menu
@@ -55,7 +55,7 @@ The task list uses colors to highlight different states and priorities:
 - `task.py`: Defines the `Task` class representing a single task.
 - `controller.py`: Defines the `TaskController` class for managing tasks.
 - `window.py`: Defines the `Window` class for creating the main GUI window.
-- `object.pkl`: Pickle file to store tasks.
+- `tasks.json`: JSON file to store tasks.
 - `Start.bat`: Windows script to launch the application.
 - `Start.sh`: Shell script to launch the application on Unix systems.
 ## Running Tests

--- a/orga.py
+++ b/orga.py
@@ -1,12 +1,12 @@
 """
 This script demonstrates a simple to-do list application using tkinter.
 It allows users to create, edit, and delete tasks. The tasks can be
-saved to a file ('object.pkl') upon closing the application.
+saved to a JSON file (``tasks.json``) upon closing the application.
 
 Modules:
 - tkinter: provides the Tk GUI toolkit for building the application's GUI.
 - messagebox: a sub-module of tkinter used for displaying message boxes.
-- pickle: for serializing and deserializing Python object structures.
+- persistence: helper functions for saving and loading task data in JSON.
 
 Classes:
 - Task: represents a single task in the to-do list.
@@ -22,32 +22,15 @@ Usage:
 """
 import tkinter as tk
 from tkinter import messagebox as tkMessageBox
-import pickle
 from task import Task
 from window import Window
 from controller import TaskController
+from persistence import load_tasks_from_json, save_tasks_to_json
 
 
 def load_tasks():
-    """Load tasks from 'object.pkl'.
-
-    Returns a Task object. If the file is missing or cannot be
-    unpickled, a new ``Task('Main')`` is returned and the user is
-    warned.
-    """
-    try:
-        with open("object.pkl", "rb") as f:
-            return pickle.load(f)
-    except (FileNotFoundError, pickle.UnpicklingError, OSError) as err:
-        try:
-            tkMessageBox.showwarning(
-                "Load Error",
-                "Failed to load saved tasks, starting with a new list.",
-            )
-        except Exception:
-            # In testing environments the message box may not be available
-            pass
-        return Task("Main")
+    """Load tasks from ``tasks.json`` using JSON persistence."""
+    return load_tasks_from_json("tasks.json")
 
 
 # Main program
@@ -62,9 +45,8 @@ def _tasks_equal(t1, t2):
 def on_closing(task, rt):
     """Handle the closing event and optionally save modifications."""
     try:
-        with open("object.pkl", "rb") as fh:
-            existing = pickle.load(fh)
-    except (FileNotFoundError, pickle.UnpicklingError, OSError):
+        existing = load_tasks_from_json("tasks.json")
+    except Exception:
         existing = None
 
     if existing is not None and _tasks_equal(task, existing):
@@ -73,8 +55,7 @@ def on_closing(task, rt):
 
     save_changes = tkMessageBox.askyesno("Quit", "Save your modification?")
     if save_changes:
-        with open("object.pkl", "wb") as file:
-            pickle.dump(task, file)
+        save_tasks_to_json(task, "tasks.json")
     rt.destroy()
 
 

--- a/tests/test_pickle_save.py
+++ b/tests/test_pickle_save.py
@@ -1,9 +1,10 @@
 import os, sys
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
-import pickle
+import json
 import builtins
 from task import Task
 from orga import on_closing, load_tasks, tkMessageBox
+from persistence import load_tasks_from_json, save_tasks_to_json
 
 
 def test_on_closing_saves_and_loads(tmp_path, monkeypatch):
@@ -20,11 +21,11 @@ def test_on_closing_saves_and_loads(tmp_path, monkeypatch):
             self.destroyed = True
 
     root = DummyRoot()
-    file_path = tmp_path / 'object.pkl'
+    file_path = tmp_path / 'tasks.json'
 
     original_open = builtins.open
     def fake_open(path, mode='r', *args, **kwargs):
-        if path == 'object.pkl':
+        if path == 'tasks.json':
             return original_open(file_path, mode, *args, **kwargs)
         return original_open(path, mode, *args, **kwargs)
 
@@ -33,8 +34,7 @@ def test_on_closing_saves_and_loads(tmp_path, monkeypatch):
     on_closing(main, root)
     assert root.destroyed
 
-    with original_open(file_path, 'rb') as f:
-        loaded = pickle.load(f)
+    loaded = load_tasks_from_json(file_path)
 
     assert loaded.name == 'Main'
     loaded_sub = loaded.get_sub_tasks()[0]
@@ -44,26 +44,24 @@ def test_on_closing_saves_and_loads(tmp_path, monkeypatch):
     assert loaded_sub.completed
 
 
-def test_load_tasks_with_corrupt_pickle(tmp_path, monkeypatch):
-    bad_file = tmp_path / 'object.pkl'
-    bad_file.write_bytes(b'not a pickle')
+def test_load_tasks_with_corrupt_json(tmp_path, monkeypatch, capsys):
+    bad_file = tmp_path / 'tasks.json'
+    bad_file.write_text('not json', encoding='utf-8')
 
     original_open = builtins.open
 
-    def fake_open(path, mode='rb', *args, **kwargs):
-        if path == 'object.pkl':
+    def fake_open(path, mode='r', *args, **kwargs):
+        if path == 'tasks.json':
             return original_open(bad_file, mode, *args, **kwargs)
         return original_open(path, mode, *args, **kwargs)
 
     monkeypatch.setattr(builtins, 'open', fake_open)
 
-    warnings = []
-    monkeypatch.setattr(tkMessageBox, 'showwarning', lambda *a, **k: warnings.append(True))
-
     task = load_tasks()
     assert isinstance(task, Task)
     assert task.name == 'Main'
-    assert warnings  # ensure warning was triggered
+    captured = capsys.readouterr()
+    assert 'Warning:' in captured.out
 
 
 def test_on_closing_no_prompt_when_unmodified(tmp_path, monkeypatch):
@@ -71,14 +69,13 @@ def test_on_closing_no_prompt_when_unmodified(tmp_path, monkeypatch):
     main = Task('Main')
     main.add_sub_task(Task('Sub'))
 
-    file_path = tmp_path / 'object.pkl'
-    with open(file_path, 'wb') as f:
-        pickle.dump(main, f)
+    file_path = tmp_path / 'tasks.json'
+    save_tasks_to_json(main, file_path)
 
     original_open = builtins.open
 
     def fake_open(path, mode='r', *args, **kwargs):
-        if path == 'object.pkl':
+        if path == 'tasks.json':
             return original_open(file_path, mode, *args, **kwargs)
         return original_open(path, mode, *args, **kwargs)
 


### PR DESCRIPTION
## Summary
- update `orga.py` to read/write `tasks.json` via the persistence module
- switch related tests from pickle handling to JSON
- document JSON usage in README
- ignore `tasks.json`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878e9daf75883338c0a6ad1e3c14611