### PR TITLE
Handle missing JSON task name

### DIFF
--- a/task.py
+++ b/task.py
@@ -138,9 +138,16 @@ class Task:
     def from_dict(cls, data):
         """Create a ``Task`` from a dictionary produced by :py:meth:`to_dict`."""
         name = data.get("name")
+        if not name:
+            name = "Unnamed"
         sub_tasks = [cls.from_dict(d) for d in data.get("sub_tasks", [])]
         due_date = data.get("due_date")
         priority = data.get("priority")
         completed = data.get("completed", False)
-        return cls(name, sub_tasks=sub_tasks, due_date=due_date,
-                   priority=priority, completed=completed)
+        return cls(
+            name,
+            sub_tasks=sub_tasks,
+            due_date=due_date,
+            priority=priority,
+            completed=completed,
+        )

--- a/tests/test_json_persistence.py
+++ b/tests/test_json_persistence.py
@@ -60,3 +60,14 @@ def test_load_tasks_with_invalid_json(tmp_path):
     assert isinstance(task, Task)
     assert task.name == 'Main'
 
+
+def test_load_without_name_field(tmp_path):
+    """Loading a JSON task without a name should default the name."""
+    path = tmp_path / 'noname.json'
+    path.write_text('{"sub_tasks": []}', encoding='utf-8')
+
+    task = load_tasks_from_json(path)
+
+    assert isinstance(task, Task)
+    assert task.name == 'Unnamed'
+


### PR DESCRIPTION
## Summary
- handle missing or falsy `name` in `Task.from_dict`
- ensure JSON load without a `name` field assigns `'Unnamed'`
- test loading JSON without a name field

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878e9e1eb448333a03955d6dd730d07