### PR TITLE
Remove unused variable in load_tasks

### DIFF
--- a/orga.py
+++ b/orga.py
@@ -38,7 +38,7 @@ def load_tasks():
     try:
         with open("object.pkl", "rb") as f:
             return pickle.load(f)
-    except (FileNotFoundError, pickle.UnpicklingError, OSError) as err:
+    except (FileNotFoundError, pickle.UnpicklingError, OSError):
         try:
             tkMessageBox.showwarning(
                 "Load Error",


### PR DESCRIPTION
## Summary
- cleanup: remove the unused `err` variable in `orga.load_tasks`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878ea0303ac833385d1f103f2561e00