### PR TITLE
Refresh parent window after subtask updates

### DIFF
--- a/persistence.py
+++ b/persistence.py
@@ -25,4 +25,5 @@ def load_tasks_from_json(path):
         return Task.from_dict(data)
     except (FileNotFoundError, json.JSONDecodeError, OSError, TypeError) as err:
         logger.warning("Failed to load tasks from %s: %s", path, err)
+        print("Warning:", err)
         return Task("Main")

--- a/tests/test_window.py
+++ b/tests/test_window.py
@@ -1,4 +1,5 @@
 import os, sys
+
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 from task import Task
 from controller import TaskController
@@ -13,9 +14,11 @@ class DummyRoot:
 
 class DummyStringVar:
     def __init__(self):
-        self.value = ''
+        self.value = ""
+
     def set(self, v):
         self.value = v
+
     def get(self):
         return self.value
 
@@ -33,13 +36,17 @@ class DummyIntVar:
 
 class DummyWidget:
     def __init__(self, *args, **kwargs):
-        self.command = kwargs.get('command')
+        self.command = kwargs.get("command")
+
     def pack(self):
         pass
+
     def grid(self, *args, **kwargs):
         pass
+
     def destroy(self):
         pass
+
     def invoke(self):
         if self.command:
             self.command()
@@ -49,8 +56,9 @@ class DummyEntry(DummyWidget):
     def __init__(self, *args, textvariable=None, **kwargs):
         super().__init__(*args, **kwargs)
         self.textvariable = textvariable
+
     def get(self):
-        return self.textvariable.get() if self.textvariable else ''
+        return self.textvariable.get() if self.textvariable else ""
 
 
 class DummyCheckbutton(DummyWidget):
@@ -122,7 +130,8 @@ class DummyTreeview(DummyWidget):
 
 
 class DummyListbox(DummyWidget):
-    END = 'end'
+    END = "end"
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.items = []
@@ -130,19 +139,27 @@ class DummyListbox(DummyWidget):
         self.bindings = {}
         self.config_called_with = {}
         self.itemconfigs = {}
+
     def delete(self, start, end):
         self.items = []
+
     def insert(self, index, item):
         self.items.append(item)
+
     def curselection(self):
         return self.selection
+
     def bind(self, event, func):
         self.bindings[event] = func
+
     def yview(self, *args):
         self.yview_args = args
+
     def config(self, **kwargs):
         self.config_called_with.update(kwargs)
+
     configure = config
+
     def itemconfig(self, index, **kwargs):
         self.itemconfigs[index] = kwargs
 
@@ -152,6 +169,7 @@ class DummyScrollbar(DummyWidget):
         super().__init__(*args, **kwargs)
         self.orient = orient
         self.command = command
+
     def set(self, *args):
         self.set_args = args
 
@@ -192,7 +210,7 @@ class DummyRootWithConfig(DummyRoot):
 
 
 class DummyTkModule:
-    END = 'end'
+    END = "end"
     Label = DummyWidget
     Button = DummyWidget
     Entry = DummyEntry
@@ -222,28 +240,28 @@ class DummyStyleWithThemes(DummyStyle):
 
 def setup_window(monkeypatch):
     fake_tk = DummyTkModule()
-    monkeypatch.setattr(window, 'tk', fake_tk)
-    monkeypatch.setattr(window, 'ttk', fake_tk)
-    monkeypatch.setattr(window, 'DateEntry', DummyEntry)
+    monkeypatch.setattr(window, "tk", fake_tk)
+    monkeypatch.setattr(window, "ttk", fake_tk)
+    monkeypatch.setattr(window, "DateEntry", DummyEntry)
     root = DummyRoot()
-    controller = TaskController(Task('Main'))
+    controller = TaskController(Task("Main"))
     return window.Window(root, controller)
 
 
 def test_window_initial_refresh(monkeypatch):
     win = setup_window(monkeypatch)
     assert win.tree.items == []
-    win.controller.add_task('Task1')
+    win.controller.add_task("Task1")
     win.refresh_window()
-    assert win.tree.items == ['Task1']
+    assert win.tree.items == ["Task1"]
 
 
 def test_scrollbar_connected(monkeypatch):
     win = setup_window(monkeypatch)
     assert isinstance(win.scrollbar, DummyScrollbar)
     assert win.scrollbar.command == win.tree.yview
-    cmd = win.tree.config_called_with.get('yscrollcommand')
-    assert getattr(cmd, '__self__', None) is win.scrollbar
+    cmd = win.tree.config_called_with.get("yscrollcommand")
+    assert getattr(cmd, "__self__", None) is win.scrollbar
 
 
 def test_create_task_button(monkeypatch):
@@ -253,32 +271,34 @@ def test_create_task_button(monkeypatch):
     prio = DummyEntry(textvariable=DummyStringVar())
     chk_var = DummyIntVar()
     chk = DummyCheckbutton(variable=chk_var)
-    entry.textvariable.set('New')
-    due.textvariable.set('2025-12-31')
-    prio.textvariable.set('2')
+    entry.textvariable.set("New")
+    due.textvariable.set("2025-12-31")
+    prio.textvariable.set("2")
     chk_var.set(1)
     btn = DummyWidget()
     win.create_task_button(entry, due, prio, chk_var, chk, btn)
     t = win.controller.get_sub_tasks()[0]
-    assert t.name == 'New'
-    assert t.due_date == '2025-12-31'
+    assert t.name == "New"
+    assert t.due_date == "2025-12-31"
     assert t.priority == 2
     assert t.completed
-    assert win.tree.items == ['New (Completed) - Due: 2025-12-31 - Priority: 2']
+    assert win.tree.items == ["New (Completed) - Due: 2025-12-31 - Priority: 2"]
 
 
 def test_create_task_button_invalid_priority(monkeypatch):
     win = setup_window(monkeypatch)
     warnings = []
-    monkeypatch.setattr(window.tkMessageBox, 'showwarning', lambda *a, **k: warnings.append(True))
+    monkeypatch.setattr(
+        window.tkMessageBox, "showwarning", lambda *a, **k: warnings.append(True)
+    )
     entry = DummyEntry(textvariable=DummyStringVar())
     due = DummyEntry(textvariable=DummyStringVar())
     prio = DummyEntry(textvariable=DummyStringVar())
     chk_var = DummyIntVar()
     chk = DummyCheckbutton(variable=chk_var)
-    entry.textvariable.set('New')
-    due.textvariable.set('2025-12-31')
-    prio.textvariable.set('bad')
+    entry.textvariable.set("New")
+    due.textvariable.set("2025-12-31")
+    prio.textvariable.set("bad")
     chk_var.set(0)
     btn = DummyWidget()
     win.create_task_button(entry, due, prio, chk_var, chk, btn)
@@ -289,14 +309,14 @@ def test_create_task_button_invalid_priority(monkeypatch):
 
 def test_confirm_edit(monkeypatch):
     win = setup_window(monkeypatch)
-    win.controller.add_task('Old')
+    win.controller.add_task("Old")
     win.refresh_window()
     var = DummyStringVar()
-    var.set('Updated')
+    var.set("Updated")
     due_var = DummyStringVar()
-    due_var.set('2026-01-01')
+    due_var.set("2026-01-01")
     prio_var = DummyStringVar()
-    prio_var.set('3')
+    prio_var.set("3")
     chk_var = DummyIntVar()
     chk_var.set(1)
     item = win.tree.get_children()[0]
@@ -308,22 +328,28 @@ def test_confirm_edit(monkeypatch):
     btn = DummyWidget()
     win.confirm_edit(entry, due_entry, prio_entry, chk_var, chk, item, btn)
     t = win.controller.get_sub_tasks()[0]
-    assert t.name == 'Updated'
-    assert t.due_date == '2026-01-01'
+    assert t.name == "Updated"
+    assert t.due_date == "2026-01-01"
     assert t.priority == 3
     assert t.completed
 
 
 def test_confirm_edit_invalid_priority(monkeypatch):
     win = setup_window(monkeypatch)
-    win.controller.add_task('Old')
+    win.controller.add_task("Old")
     win.refresh_window()
     warnings = []
-    monkeypatch.setattr(window.tkMessageBox, 'showwarning', lambda *a, **k: warnings.append(True))
-    var = DummyStringVar(); var.set('Updated')
-    due_var = DummyStringVar(); due_var.set('2026-01-01')
-    prio_var = DummyStringVar(); prio_var.set('bad')
-    chk_var = DummyIntVar(); chk_var.set(0)
+    monkeypatch.setattr(
+        window.tkMessageBox, "showwarning", lambda *a, **k: warnings.append(True)
+    )
+    var = DummyStringVar()
+    var.set("Updated")
+    due_var = DummyStringVar()
+    due_var.set("2026-01-01")
+    prio_var = DummyStringVar()
+    prio_var.set("bad")
+    chk_var = DummyIntVar()
+    chk_var.set(0)
     item = win.tree.get_children()[0]
     win.tree.selection_set(item)
     entry = DummyEntry(textvariable=var)
@@ -347,21 +373,21 @@ def test_edit_task_prefills_fields(monkeypatch):
 
     fake_tk = DummyTkModule()
     fake_tk.Entry = TrackedEntry
-    monkeypatch.setattr(window, 'tk', fake_tk)
-    monkeypatch.setattr(window, 'ttk', fake_tk)
-    monkeypatch.setattr(window, 'DateEntry', TrackedEntry)
+    monkeypatch.setattr(window, "tk", fake_tk)
+    monkeypatch.setattr(window, "ttk", fake_tk)
+    monkeypatch.setattr(window, "DateEntry", TrackedEntry)
     root = DummyRoot()
-    controller = TaskController(Task('Main'))
-    controller.add_task('Existing', due_date='2024-12-31', priority=2)
+    controller = TaskController(Task("Main"))
+    controller.add_task("Existing", due_date="2024-12-31", priority=2)
     win = window.Window(root, controller)
     entries.clear()  # ignore widgets created during initialization
     item = win.tree.get_children()[0]
     win.tree.selection_set(item)
     win.edit_task()
 
-    assert entries[0].get() == 'Existing'
-    assert entries[1].get() == '2024-12-31'
-    assert entries[2].get() == '2'
+    assert entries[0].get() == "Existing"
+    assert entries[1].get() == "2024-12-31"
+    assert entries[2].get() == "2"
 
 
 def test_edit_subtask_prefills_fields(monkeypatch):
@@ -374,13 +400,13 @@ def test_edit_subtask_prefills_fields(monkeypatch):
 
     fake_tk = DummyTkModule()
     fake_tk.Entry = TrackEntry
-    monkeypatch.setattr(window, 'tk', fake_tk)
-    monkeypatch.setattr(window, 'ttk', fake_tk)
-    monkeypatch.setattr(window, 'DateEntry', TrackEntry)
+    monkeypatch.setattr(window, "tk", fake_tk)
+    monkeypatch.setattr(window, "ttk", fake_tk)
+    monkeypatch.setattr(window, "DateEntry", TrackEntry)
     root = DummyRoot()
-    controller = TaskController(Task('Main'))
-    parent = Task('Parent')
-    parent.add_sub_task(Task('Child', due_date='2025-01-01', priority=5))
+    controller = TaskController(Task("Main"))
+    parent = Task("Parent")
+    parent.add_sub_task(Task("Child", due_date="2025-01-01", priority=5))
     controller.task.add_sub_task(parent)
     win = window.Window(root, controller)
     sub_root = DummyRoot()
@@ -390,9 +416,9 @@ def test_edit_subtask_prefills_fields(monkeypatch):
     sub_win.tree.selection_set(item)
     sub_win.edit_task()
 
-    assert entries[0].get() == 'Child'
-    assert entries[1].get() == '2025-01-01'
-    assert entries[2].get() == '5'
+    assert entries[0].get() == "Child"
+    assert entries[1].get() == "2025-01-01"
+    assert entries[2].get() == "5"
 
 
 def test_edit_task_keeps_vars(monkeypatch):
@@ -404,67 +430,71 @@ def test_edit_task_keeps_vars(monkeypatch):
 
     def fake_top(parent=None):
         dlg = CapRoot()
-        captured['dlg'] = dlg
+        captured["dlg"] = dlg
         return dlg
 
     fake_tk = DummyTkModule()
     fake_tk.Toplevel = fake_top
-    monkeypatch.setattr(window, 'tk', fake_tk)
-    monkeypatch.setattr(window, 'ttk', fake_tk)
-    monkeypatch.setattr(window, 'DateEntry', DummyEntry)
+    monkeypatch.setattr(window, "tk", fake_tk)
+    monkeypatch.setattr(window, "ttk", fake_tk)
+    monkeypatch.setattr(window, "DateEntry", DummyEntry)
     root = DummyRoot()
-    controller = TaskController(Task('Main'))
-    controller.add_task('X', due_date='2023-01-01', priority=1)
+    controller = TaskController(Task("Main"))
+    controller.add_task("X", due_date="2023-01-01", priority=1)
     win = window.Window(root, controller)
     item = win.tree.get_children()[0]
     win.tree.selection_set(item)
     win.edit_task()
 
-    dlg = captured['dlg']
-    assert hasattr(dlg, 'task_name_var')
-    assert dlg.task_name_var.get() == 'X'
-    assert dlg.due_date_var.get() == '2023-01-01'
-    assert dlg.priority_var.get() == '1'
+    dlg = captured["dlg"]
+    assert hasattr(dlg, "task_name_var")
+    assert dlg.task_name_var.get() == "X"
+    assert dlg.due_date_var.get() == "2023-01-01"
+    assert dlg.priority_var.get() == "1"
 
 
 def test_sort_button(monkeypatch):
     win = setup_window(monkeypatch)
-    win.controller.add_task('Low', priority=5)
-    win.controller.add_task('High', priority=1)
-    win.controller.add_task('None')
+    win.controller.add_task("Low", priority=5)
+    win.controller.add_task("High", priority=1)
+    win.controller.add_task("None")
     win.sort_tasks_by_priority()
-    assert [t.name for t in win.controller.get_sub_tasks()] == ['High', 'Low', 'None']
-    assert [item.split()[0] for item in win.tree.items] == ['High', 'Low', 'None']
+    assert [t.name for t in win.controller.get_sub_tasks()] == ["High", "Low", "None"]
+    assert [item.split()[0] for item in win.tree.items] == ["High", "Low", "None"]
 
 
 def test_sort_by_due_date(monkeypatch):
     win = setup_window(monkeypatch)
-    win.controller.add_task('Later', due_date='2025-01-01')
-    win.controller.add_task('Sooner', due_date='2024-01-01')
-    win.controller.add_task('NoDue')
+    win.controller.add_task("Later", due_date="2025-01-01")
+    win.controller.add_task("Sooner", due_date="2024-01-01")
+    win.controller.add_task("NoDue")
     win.sort_tasks_by_due_date()
-    assert [t.name for t in win.controller.get_sub_tasks()] == ['Sooner', 'Later', 'NoDue']
-    assert [item.split()[0] for item in win.tree.items] == ['Sooner', 'Later', 'NoDue']
+    assert [t.name for t in win.controller.get_sub_tasks()] == [
+        "Sooner",
+        "Later",
+        "NoDue",
+    ]
+    assert [item.split()[0] for item in win.tree.items] == ["Sooner", "Later", "NoDue"]
 
 
 def test_search_filter(monkeypatch):
     win = setup_window(monkeypatch)
-    win.controller.add_task('Hello')
-    win.controller.add_task('World')
-    win.controller.add_task('Help')
-    win.search_var.set('hel')
+    win.controller.add_task("Hello")
+    win.controller.add_task("World")
+    win.controller.add_task("Help")
+    win.search_var.set("hel")
     win.refresh_window()
-    assert [item.split()[0] for item in win.tree.items] == ['Hello', 'Help']
+    assert [item.split()[0] for item in win.tree.items] == ["Hello", "Help"]
 
 
 def test_hide_completed(monkeypatch):
     win = setup_window(monkeypatch)
-    win.controller.add_task('Done')
-    win.controller.add_task('Todo')
+    win.controller.add_task("Done")
+    win.controller.add_task("Todo")
     win.controller.mark_task_completed(0)
     win.hide_completed_var.set(1)
     win.refresh_window()
-    assert [item.split()[0] for item in win.tree.items] == ['Todo']
+    assert [item.split()[0] for item in win.tree.items] == ["Todo"]
 
 
 def test_hide_checkbox_triggers_refresh(monkeypatch):
@@ -473,46 +503,46 @@ def test_hide_checkbox_triggers_refresh(monkeypatch):
     class TrackCheck(DummyCheckbutton):
         def __init__(self, *args, **kwargs):
             super().__init__(*args, **kwargs)
-            created['cb'] = self
+            created["cb"] = self
 
     fake_tk = DummyTkModule()
     fake_tk.Checkbutton = TrackCheck
-    monkeypatch.setattr(window, 'tk', fake_tk)
-    monkeypatch.setattr(window, 'ttk', fake_tk)
-    monkeypatch.setattr(window, 'DateEntry', DummyEntry)
+    monkeypatch.setattr(window, "tk", fake_tk)
+    monkeypatch.setattr(window, "ttk", fake_tk)
+    monkeypatch.setattr(window, "DateEntry", DummyEntry)
 
     root = DummyRoot()
-    controller = TaskController(Task('Main'))
-    controller.add_task('Done')
-    controller.add_task('Todo')
+    controller = TaskController(Task("Main"))
+    controller.add_task("Done")
+    controller.add_task("Todo")
     controller.mark_task_completed(0)
     win = window.Window(root, controller)
 
-    cb = created.get('cb')
+    cb = created.get("cb")
     assert cb is not None
     assert cb.command == win.refresh_window
 
     win.hide_completed_var.set(1)
     cb.invoke()
-    assert [item.split()[0] for item in win.tree.items] == ['Todo']
+    assert [item.split()[0] for item in win.tree.items] == ["Todo"]
 
 
 def test_double_click_opens_subtasks(monkeypatch):
     called = {}
 
     def fake_view(self):
-        called['view'] = True
+        called["view"] = True
 
-    monkeypatch.setattr(window.Window, 'view_subtasks', fake_view)
+    monkeypatch.setattr(window.Window, "view_subtasks", fake_view)
     win = setup_window(monkeypatch)
-    win.controller.add_task('A')
+    win.controller.add_task("A")
     win.refresh_window()
     item = win.tree.get_children()[0]
     win.tree.selection_set(item)
-    bound = win.tree.bindings.get('<Double-Button-1>')
+    bound = win.tree.bindings.get("<Double-Button-1>")
     assert bound is not None
     bound(None)
-    assert called.get('view')
+    assert called.get("view")
 
 
 def test_view_subtasks_uses_toplevel(monkeypatch):
@@ -524,149 +554,176 @@ def test_view_subtasks_uses_toplevel(monkeypatch):
     fake_tk = FakeTk()
 
     def toplevel(parent=None):
-        created['parent'] = parent
+        created["parent"] = parent
         return DummyRoot()
 
     fake_tk.Toplevel = toplevel
 
     def fake_tk_root(*args, **kwargs):
-        created['tk_called'] = True
+        created["tk_called"] = True
         return DummyRoot()
 
     fake_tk.Tk = fake_tk_root
 
-    monkeypatch.setattr(window, 'tk', fake_tk)
-    monkeypatch.setattr(window, 'ttk', fake_tk)
-    monkeypatch.setattr(window, 'DateEntry', DummyEntry)
+    monkeypatch.setattr(window, "tk", fake_tk)
+    monkeypatch.setattr(window, "ttk", fake_tk)
+    monkeypatch.setattr(window, "DateEntry", DummyEntry)
 
     root = DummyRoot()
-    controller = TaskController(Task('Main'))
-    controller.add_task('Sub')
+    controller = TaskController(Task("Main"))
+    controller.add_task("Sub")
     win = window.Window(root, controller)
     item = win.tree.get_children()[0]
     win.tree.selection_set(item)
 
     win.view_subtasks()
 
-    assert created.get('parent') is root
-    assert 'tk_called' not in created
+    assert created.get("parent") is root
+    assert "tk_called" not in created
 
 
 def test_completed_task_gray(monkeypatch):
     win = setup_window(monkeypatch)
-    win.controller.add_task('Done')
+    win.controller.add_task("Done")
     win.controller.mark_task_completed(0)
     win.refresh_window()
     iid = win.tree.get_children()[0]
-    assert win.tree.nodes[iid]['tags'][0] == 'gray'
+    assert win.tree.nodes[iid]["tags"][0] == "gray"
 
 
 def test_overdue_task_red(monkeypatch):
     win = setup_window(monkeypatch)
     past = (datetime.date.today() - datetime.timedelta(days=1)).isoformat()
-    win.controller.add_task('Late', due_date=past)
+    win.controller.add_task("Late", due_date=past)
     win.refresh_window()
     iid = win.tree.get_children()[0]
-    assert win.tree.nodes[iid]['tags'][0] == 'red'
+    assert win.tree.nodes[iid]["tags"][0] == "red"
 
 
 def test_due_date_filter_before(monkeypatch):
     win = setup_window(monkeypatch)
-    win.controller.add_task('Soon', due_date='2024-01-01')
-    win.controller.add_task('Later', due_date='2026-01-01')
-    win.due_filter_var.set('2025-01-01')
+    win.controller.add_task("Soon", due_date="2024-01-01")
+    win.controller.add_task("Later", due_date="2026-01-01")
+    win.due_filter_var.set("2025-01-01")
     win.due_before_var.set(1)
     win.refresh_window()
-    assert [item.split()[0] for item in win.tree.items] == ['Soon']
+    assert [item.split()[0] for item in win.tree.items] == ["Soon"]
 
 
 def test_due_date_filter_after(monkeypatch):
     win = setup_window(monkeypatch)
-    win.controller.add_task('Soon', due_date='2024-01-01')
-    win.controller.add_task('Later', due_date='2026-01-01')
-    win.due_filter_var.set('2025-01-01')
+    win.controller.add_task("Soon", due_date="2024-01-01")
+    win.controller.add_task("Later", due_date="2026-01-01")
+    win.due_filter_var.set("2025-01-01")
     win.due_after_var.set(1)
     win.refresh_window()
-    assert [item.split()[0] for item in win.tree.items] == ['Later']
+    assert [item.split()[0] for item in win.tree.items] == ["Later"]
 
 
 def test_priority_filter_above(monkeypatch):
     win = setup_window(monkeypatch)
-    win.controller.add_task('Low', priority=5)
-    win.controller.add_task('High', priority=1)
-    win.priority_filter_var.set('2')
+    win.controller.add_task("Low", priority=5)
+    win.controller.add_task("High", priority=1)
+    win.priority_filter_var.set("2")
     win.priority_above_var.set(1)
     win.refresh_window()
-    assert [item.split()[0] for item in win.tree.items] == ['Low']
+    assert [item.split()[0] for item in win.tree.items] == ["Low"]
 
 
 def test_priority_filter_below(monkeypatch):
     win = setup_window(monkeypatch)
-    win.controller.add_task('Low', priority=5)
-    win.controller.add_task('High', priority=1)
-    win.priority_filter_var.set('3')
+    win.controller.add_task("Low", priority=5)
+    win.controller.add_task("High", priority=1)
+    win.priority_filter_var.set("3")
     win.priority_below_var.set(1)
     win.refresh_window()
-    assert [item.split()[0] for item in win.tree.items] == ['High']
+    assert [item.split()[0] for item in win.tree.items] == ["High"]
+
+
 def test_priority_colors(monkeypatch):
     win = setup_window(monkeypatch)
-    win.controller.add_task('High', priority=1)
-    win.controller.add_task('Medium', priority=2)
+    win.controller.add_task("High", priority=1)
+    win.controller.add_task("Medium", priority=2)
     win.refresh_window()
     iid0, iid1 = win.tree.get_children()
-    assert win.tree.nodes[iid0]['tags'][0] == 'red'
-    assert win.tree.nodes[iid1]['tags'][0] == 'orange'
+    assert win.tree.nodes[iid0]["tags"][0] == "red"
+    assert win.tree.nodes[iid1]["tags"][0] == "orange"
 
 
 def test_priority_completed_overdue_coexist(monkeypatch):
     win = setup_window(monkeypatch)
     past = (datetime.date.today() - datetime.timedelta(days=1)).isoformat()
-    win.controller.add_task('DoneHigh', priority=1)
+    win.controller.add_task("DoneHigh", priority=1)
     win.controller.mark_task_completed(0)
-    win.controller.add_task('OverdueMedium', due_date=past, priority=2)
+    win.controller.add_task("OverdueMedium", due_date=past, priority=2)
     win.refresh_window()
     # Completed task should remain gray despite priority
     iid0, iid1 = win.tree.get_children()
-    assert win.tree.nodes[iid0]['tags'][0] == 'gray'
+    assert win.tree.nodes[iid0]["tags"][0] == "gray"
     # Overdue task should be red despite medium priority
-    assert win.tree.nodes[iid1]['tags'][0] == 'red'
+    assert win.tree.nodes[iid1]["tags"][0] == "red"
 
 
 def test_view_menu_themes(monkeypatch):
     fake_tk = MenuTkModule()
     fake_tk.Style = DummyStyleWithThemes
-    monkeypatch.setattr(window, 'tk', fake_tk)
-    monkeypatch.setattr(window, 'ttk', fake_tk)
-    monkeypatch.setattr(window, 'DateEntry', DummyEntry)
+    monkeypatch.setattr(window, "tk", fake_tk)
+    monkeypatch.setattr(window, "ttk", fake_tk)
+    monkeypatch.setattr(window, "DateEntry", DummyEntry)
     root = DummyRootWithConfig()
-    controller = TaskController(Task('Main'))
+    controller = TaskController(Task("Main"))
     win = window.Window(root, controller)
 
-    menubar = root.config_kwargs.get('menu')
+    menubar = root.config_kwargs.get("menu")
     assert isinstance(menubar, DummyMenu)
     view_menu = None
     for label, menu in menubar.cascades:
-        if label == 'View':
+        if label == "View":
             view_menu = menu
     assert view_menu is not None
-    assert [lbl for lbl, _ in view_menu.commands] == ['light', 'dark']
+    assert [lbl for lbl, _ in view_menu.commands] == ["light", "dark"]
 
     called = {}
-    monkeypatch.setattr(win, 'use_theme', lambda t: called.setdefault('theme', t))
+    monkeypatch.setattr(win, "use_theme", lambda t: called.setdefault("theme", t))
     # trigger second theme command
     view_menu.commands[1][1]()
-    assert called.get('theme') == 'dark'
+    assert called.get("theme") == "dark"
 
 
 def test_tree_shows_subtasks(monkeypatch):
     win = setup_window(monkeypatch)
-    parent = Task('Parent')
-    parent.add_sub_task(Task('Child'))
+    parent = Task("Parent")
+    parent.add_sub_task(Task("Child"))
     win.controller.task.add_sub_task(parent)
     win.refresh_window()
 
-    parent_id = win.tree.get_children()[0]
+    parent_ids = win.tree.get_children()
+    parent_id = parent_ids[-1]
     child_ids = win.tree.get_children(parent_id)
     assert len(child_ids) == 1
-    assert win.tree.nodes[child_ids[0]]['text'].startswith('Child')
+    assert win.tree.nodes[child_ids[0]]["text"].startswith("Child")
 
+
+def test_subwindow_add_refreshes_parent(monkeypatch):
+    win = setup_window(monkeypatch)
+    parent = Task("Parent")
+    win.controller.task.add_sub_task(parent)
+    win.refresh_window()
+
+    sub_root = DummyRoot()
+    sub_win = window.Window(sub_root, TaskController(parent), parent_window=win)
+
+    entry = DummyEntry(textvariable=DummyStringVar())
+    due = DummyEntry(textvariable=DummyStringVar())
+    prio = DummyEntry(textvariable=DummyStringVar())
+    chk_var = DummyIntVar()
+    chk = DummyCheckbutton(variable=chk_var)
+    entry.textvariable.set("Child")
+    btn = DummyWidget()
+    sub_win.create_task_button(entry, due, prio, chk_var, chk, btn)
+
+    parent_ids = win.tree.get_children()
+    parent_id = parent_ids[-1]
+    child_ids = win.tree.get_children(parent_id)
+    assert len(child_ids) == 1
+    assert win.tree.nodes[child_ids[0]]["text"].startswith("Child")


### PR DESCRIPTION
## Summary
- track parent window when creating a `Window`
- refresh parent when adding, editing, deleting, sorting or importing tasks
- pass parent window when viewing subtasks
- print a warning while logging when failing to load JSON
- test that adding a subtask refreshes the parent window

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68796cc938ec8333a58e454a58bcf2f4