### PR TITLE
Fix theme reset when opening subtask windows

### DIFF
--- a/tests/test_window.py
+++ b/tests/test_window.py
@@ -727,3 +727,23 @@ def test_subwindow_add_refreshes_parent(monkeypatch):
     child_ids = win.tree.get_children(parent_id)
     assert len(child_ids) == 1
     assert win.tree.nodes[child_ids[0]]["text"].startswith("Child")
+
+
+def test_subwindow_inherits_theme(monkeypatch):
+    fake_tk = MenuTkModule()
+    fake_tk.Style = DummyStyleWithThemes
+    monkeypatch.setattr(window, "tk", fake_tk)
+    monkeypatch.setattr(window, "ttk", fake_tk)
+    monkeypatch.setattr(window, "DateEntry", DummyEntry)
+
+    root = DummyRoot()
+    controller = TaskController(Task("Main"))
+    main_win = window.Window(root, controller)
+    # Change the main window's theme
+    main_win.style.theme_use("dark")
+
+    sub_root = DummyRoot()
+    sub_controller = TaskController(Task("Sub"))
+    sub_win = window.Window(sub_root, sub_controller, parent_window=main_win)
+
+    assert sub_win.style.used == "dark"

--- a/window.py
+++ b/window.py
@@ -162,22 +162,33 @@ class Window:
         self.parent_window = parent_window
         self.name = controller.get_task_name()
 
+        # Determine which theme to apply.  If a parent window exists, re-use its
+        # current theme so that all windows share consistent styling.
+        theme = "flatly" if USE_BOOTSTRAP else "clam"
+        if parent_window is not None and hasattr(parent_window, "style"):
+            try:
+                existing = parent_window.style.theme_use()
+                if existing:
+                    theme = existing
+            except Exception:
+                pass
+
         # Configure ttk theme for a more modern look
         if BootstrapStyle is not None:
             try:
                 self.style = BootstrapStyle(master=self.root)
-                self.style.theme_use("flatly")
+                self.style.theme_use(theme)
             except Exception:
                 # Fallback to regular ttk in case of errors
                 self.style = ttk.Style(self.root)
                 try:
-                    self.style.theme_use("clam")
+                    self.style.theme_use(theme)
                 except Exception:
                     pass
         else:
             self.style = ttk.Style(self.root)
             try:
-                self.style.theme_use("clam")
+                self.style.theme_use(theme)
             except Exception:
                 # Fallback silently if theme is unavailable
                 pass


### PR DESCRIPTION
## Summary
- keep same ttk/ttkbootstrap theme when creating child windows
- add regression test verifying subwindow inherits parent theme

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879f5feda2083339caf007436090c40