### PR TITLE
Add task completion toggling

### DIFF
--- a/tests/test_window.py
+++ b/tests/test_window.py
@@ -545,6 +545,34 @@ def test_double_click_opens_subtasks(monkeypatch):
     assert called.get("view")
 
 
+def test_right_click_calls_toggle(monkeypatch):
+    called = {}
+
+    def fake_toggle(self):
+        called["toggle"] = True
+
+    monkeypatch.setattr(window.Window, "toggle_completion", fake_toggle)
+    win = setup_window(monkeypatch)
+    win.controller.add_task("A")
+    win.refresh_window()
+    bound = win.tree.bindings.get("<Button-3>")
+    assert bound is not None
+    bound(None)
+    assert called.get("toggle")
+
+
+def test_toggle_completion(monkeypatch):
+    win = setup_window(monkeypatch)
+    win.controller.add_task("A")
+    win.refresh_window()
+    iid = win.tree.get_children()[0]
+    win.tree.selection_set(iid)
+    win.toggle_completion()
+    t = win.controller.get_sub_tasks()[0]
+    assert t.completed
+    assert "Completed" in win.tree.items[0]
+
+
 def test_view_subtasks_uses_toplevel(monkeypatch):
     created = {}
 

--- a/window.py
+++ b/window.py
@@ -263,6 +263,8 @@ class Window:
 
         # Bind double-click on a task to open its subtasks
         self.tree.bind("<Double-Button-1>", lambda e: self.view_subtasks())
+        # Bind right-click to toggle completion status
+        self.tree.bind("<Button-3>", lambda e: self.toggle_completion())
 
         btn_opts = {"bootstyle": "secondary"} if USE_BOOTSTRAP else {}
         view_subtasks_btn = ttk.Button(
@@ -605,6 +607,22 @@ class Window:
     def sort_tasks_by_due_date(self):
         """Sort tasks by due date using the controller and refresh the view."""
         self.controller.sort_tasks_by_due_date()
+        self.refresh_window()
+        if self.parent_window is not None:
+            self.parent_window.refresh_window()
+
+    def toggle_completion(self):
+        """Toggle the completion state of the selected task."""
+        sel = self.tree.selection()
+        if not sel:
+            return
+
+        item = sel[0]
+        task, _parent = self.tree_items.get(item, (None, None))
+        if task is None:
+            return
+
+        task.completed = not task.completed
         self.refresh_window()
         if self.parent_window is not None:
             self.parent_window.refresh_window()


### PR DESCRIPTION
## Summary
- allow users to toggle task completion from the Treeview
- expose `toggle_completion` API on `Window`
- test right-click binding and completion toggling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a51e2eab08333a204b18d6ba34da4