### PR TITLE
Add CSV and ICS export support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ The Task-Manager Application is a simple graphical user interface (GUI) applicat
 - View subtasks
 - Add subtasks to a task
 - Save tasks to a JSON file for later retrieval
+- Export tasks to CSV or ICS from the File menu
 - Optional due dates and priority levels for tasks
 - Mark tasks as completed
 - Switch themes from the View menu

--- a/persistence.py
+++ b/persistence.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import csv
 from task import Task
 
 
@@ -27,3 +28,45 @@ def load_tasks_from_json(path):
         logger.warning("Failed to load tasks from %s: %s", path, err)
         print("Warning:", err)
         return Task("Main")
+
+
+def _iterate_tasks(task):
+    """Yield ``task`` and all of its subtasks recursively."""
+    yield task
+    for sub in task.get_sub_tasks():
+        yield from _iterate_tasks(sub)
+
+
+def save_tasks_to_csv(task, path):
+    """Write the task hierarchy to ``path`` in CSV format."""
+    with open(path, "w", newline="", encoding="utf-8") as fh:
+        writer = csv.writer(fh)
+        writer.writerow(["Name", "Due Date", "Priority", "Completed"])
+        for t in _iterate_tasks(task):
+            writer.writerow(
+                [
+                    t.name,
+                    t.due_date or "",
+                    "" if t.priority is None else t.priority,
+                    1 if t.completed else 0,
+                ]
+            )
+
+
+def save_tasks_to_ics(task, path):
+    """Write the task hierarchy to ``path`` as an iCalendar file."""
+    with open(path, "w", encoding="utf-8") as fh:
+        fh.write("BEGIN:VCALENDAR\n")
+        fh.write("VERSION:2.0\n")
+        fh.write("PRODID:-//Task Manager//EN\n")
+        for t in _iterate_tasks(task):
+            fh.write("BEGIN:VTODO\n")
+            fh.write(f"SUMMARY:{t.name}\n")
+            if t.due_date:
+                dt = t.due_date.replace("-", "") + "T000000Z"
+                fh.write(f"DUE:{dt}\n")
+            if t.priority is not None:
+                fh.write(f"PRIORITY:{t.priority}\n")
+            fh.write(f"STATUS:{'COMPLETED' if t.completed else 'NEEDS-ACTION'}\n")
+            fh.write("END:VTODO\n")
+        fh.write("END:VCALENDAR\n")

--- a/tests/test_export_formats.py
+++ b/tests/test_export_formats.py
@@ -1,0 +1,40 @@
+import os, sys
+import csv
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+from task import Task
+from persistence import save_tasks_to_csv, save_tasks_to_ics
+
+
+def build_task_tree():
+    main = Task('Main', due_date='2025-12-31', priority=1)
+    sub1 = Task('Sub1', completed=True)
+    sub2 = Task('Sub2', due_date='2026-01-01')
+    main.add_sub_task(sub1)
+    main.add_sub_task(sub2)
+    return main
+
+
+def test_csv_export(tmp_path):
+    task = build_task_tree()
+    path = tmp_path / 'tasks.csv'
+    save_tasks_to_csv(task, path)
+    with open(path, newline='', encoding='utf-8') as fh:
+        rows = list(csv.reader(fh))
+    assert rows[0] == ['Name', 'Due Date', 'Priority', 'Completed']
+    assert rows[1] == ['Main', '2025-12-31', '1', '0']
+    assert rows[2] == ['Sub1', '', '', '1']
+    assert rows[3] == ['Sub2', '2026-01-01', '', '0']
+
+
+def test_ics_export(tmp_path):
+    task = build_task_tree()
+    path = tmp_path / 'tasks.ics'
+    save_tasks_to_ics(task, path)
+    text = path.read_text(encoding='utf-8')
+    assert 'BEGIN:VCALENDAR' in text
+    assert 'END:VCALENDAR' in text
+    assert 'SUMMARY:Main' in text
+    assert 'SUMMARY:Sub1' in text
+    assert 'SUMMARY:Sub2' in text
+    assert 'DUE:20251231T000000Z' in text

--- a/window.py
+++ b/window.py
@@ -197,6 +197,8 @@ class Window:
             menubar = tk.Menu(self.root)
             file_menu = tk.Menu(menubar, tearoff=0)
             file_menu.add_command(label="Export to JSON", command=self.export_tasks)
+            file_menu.add_command(label="Export to CSV", command=self.export_tasks_csv)
+            file_menu.add_command(label="Export to ICS", command=self.export_tasks_ics)
             file_menu.add_command(label="Import from JSON", command=self.import_tasks)
             menubar.add_cascade(label="File", menu=file_menu)
 
@@ -623,6 +625,36 @@ class Window:
             from persistence import save_tasks_to_json
 
             save_tasks_to_json(self.controller.task, path)
+
+    def export_tasks_csv(self):
+        """Prompt for a path and export tasks as CSV."""
+        if not hasattr(tk, "filedialog"):
+            from tkinter import filedialog
+        else:
+            filedialog = tk.filedialog
+        path = filedialog.asksaveasfilename(
+            defaultextension=".csv",
+            filetypes=[("CSV files", "*.csv"), ("All files", "*.*")],
+        )
+        if path:
+            from persistence import save_tasks_to_csv
+
+            save_tasks_to_csv(self.controller.task, path)
+
+    def export_tasks_ics(self):
+        """Prompt for a path and export tasks in ICS format."""
+        if not hasattr(tk, "filedialog"):
+            from tkinter import filedialog
+        else:
+            filedialog = tk.filedialog
+        path = filedialog.asksaveasfilename(
+            defaultextension=".ics",
+            filetypes=[("iCalendar files", "*.ics"), ("All files", "*.*")],
+        )
+        if path:
+            from persistence import save_tasks_to_ics
+
+            save_tasks_to_ics(self.controller.task, path)
 
     def import_tasks(self):
         """Prompt for a JSON file and replace current tasks."""


### PR DESCRIPTION
## Summary
- export tasks to CSV/ICS via new menu commands
- implement CSV/ICS helpers in `persistence.py`
- test CSV/ICS exports
- document export options in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a51f228d88333a13e9aeb4c36cfc7