### PR TITLE
Enable CSV/ICS import

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The Task-Manager Application is a simple graphical user interface (GUI) applicat
 - View subtasks
 - Add subtasks to a task
 - Save tasks to a JSON file for later retrieval
-- Export tasks to CSV or ICS from the File menu
+- Import and export tasks in CSV, JSON, or ICS formats from the File menu
 - Optional due dates and priority levels for tasks
 - Mark tasks as completed
 - Switch themes from the View menu

--- a/tests/test_export_formats.py
+++ b/tests/test_export_formats.py
@@ -3,7 +3,12 @@ import csv
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 from task import Task
-from persistence import save_tasks_to_csv, save_tasks_to_ics
+from persistence import (
+    save_tasks_to_csv,
+    save_tasks_to_ics,
+    load_tasks_from_csv,
+    load_tasks_from_ics,
+)
 
 
 def build_task_tree():
@@ -38,3 +43,30 @@ def test_ics_export(tmp_path):
     assert 'SUMMARY:Sub1' in text
     assert 'SUMMARY:Sub2' in text
     assert 'DUE:20251231T000000Z' in text
+
+
+def test_csv_round_trip(tmp_path):
+    task = build_task_tree()
+    path = tmp_path / 'round.csv'
+    save_tasks_to_csv(task, path)
+    loaded = load_tasks_from_csv(path)
+    assert loaded.name == 'Main'
+    names = [t.name for t in loaded.get_sub_tasks()]
+    assert names == ['Sub1', 'Sub2']
+    assert loaded.due_date == '2025-12-31'
+    assert loaded.priority == 1
+    assert loaded.get_sub_tasks()[0].completed
+
+
+def test_ics_round_trip(tmp_path):
+    task = build_task_tree()
+    path = tmp_path / 'round.ics'
+    save_tasks_to_ics(task, path)
+    loaded = load_tasks_from_ics(path)
+    assert loaded.name == 'Main'
+    names = {t.name for t in loaded.get_sub_tasks()}
+    assert names == {'Sub1', 'Sub2'}
+    assert loaded.due_date == '2025-12-31'
+    assert loaded.priority == 1
+
+

--- a/window.py
+++ b/window.py
@@ -199,7 +199,9 @@ class Window:
             file_menu.add_command(label="Export to JSON", command=self.export_tasks)
             file_menu.add_command(label="Export to CSV", command=self.export_tasks_csv)
             file_menu.add_command(label="Export to ICS", command=self.export_tasks_ics)
-            file_menu.add_command(label="Import from JSON", command=self.import_tasks)
+            file_menu.add_command(label="Import from JSON", command=self.import_tasks_json)
+            file_menu.add_command(label="Import from CSV", command=self.import_tasks_csv)
+            file_menu.add_command(label="Import from ICS", command=self.import_tasks_ics)
             menubar.add_cascade(label="File", menu=file_menu)
 
             view_menu = tk.Menu(menubar, tearoff=0)
@@ -674,7 +676,7 @@ class Window:
 
             save_tasks_to_ics(self.controller.task, path)
 
-    def import_tasks(self):
+    def import_tasks_json(self):
         """Prompt for a JSON file and replace current tasks."""
         if not hasattr(tk, "filedialog"):
             from tkinter import filedialog
@@ -687,6 +689,46 @@ class Window:
             from persistence import load_tasks_from_json
 
             task = load_tasks_from_json(path)
+            self.controller.task = task
+            self.task_list = task.get_sub_tasks()
+            self.name = task.name
+            self.refresh_window()
+            if self.parent_window is not None:
+                self.parent_window.refresh_window()
+
+    def import_tasks_csv(self):
+        """Prompt for a CSV file and replace current tasks."""
+        if not hasattr(tk, "filedialog"):
+            from tkinter import filedialog
+        else:
+            filedialog = tk.filedialog
+        path = filedialog.askopenfilename(
+            filetypes=[("CSV files", "*.csv"), ("All files", "*.*")]
+        )
+        if path:
+            from persistence import load_tasks_from_csv
+
+            task = load_tasks_from_csv(path)
+            self.controller.task = task
+            self.task_list = task.get_sub_tasks()
+            self.name = task.name
+            self.refresh_window()
+            if self.parent_window is not None:
+                self.parent_window.refresh_window()
+
+    def import_tasks_ics(self):
+        """Prompt for an ICS file and replace current tasks."""
+        if not hasattr(tk, "filedialog"):
+            from tkinter import filedialog
+        else:
+            filedialog = tk.filedialog
+        path = filedialog.askopenfilename(
+            filetypes=[("iCalendar files", "*.ics"), ("All files", "*.*")]
+        )
+        if path:
+            from persistence import load_tasks_from_ics
+
+            task = load_tasks_from_ics(path)
             self.controller.task = task
             self.task_list = task.get_sub_tasks()
             self.name = task.name


### PR DESCRIPTION
## Summary
- handle CSV and ICS import alongside JSON in persistence layer
- expose import options in window menus
- document import/export in README
- test CSV and ICS import

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a698d1eb88333bf1aa3e733f55f0e