### PR TITLE
Refactor warnings to use logging

### DIFF
--- a/persistence.py
+++ b/persistence.py
@@ -26,7 +26,7 @@ def load_tasks_from_json(path):
         return Task.from_dict(data)
     except (FileNotFoundError, json.JSONDecodeError, OSError, TypeError) as err:
         logger.warning("Failed to load tasks from %s: %s", path, err)
-        print("Warning:", err)
+        logger.warning("Warning: %s", err)
         return Task("Main")
 
 
@@ -104,7 +104,7 @@ def load_tasks_from_csv(path):
         return root
     except Exception as err:
         logger.warning("Failed to load tasks from %s: %s", path, err)
-        print("Warning:", err)
+        logger.warning("Warning: %s", err)
         return Task("Main")
 
 
@@ -145,5 +145,5 @@ def load_tasks_from_ics(path):
         return root
     except Exception as err:
         logger.warning("Failed to load tasks from %s: %s", path, err)
-        print("Warning:", err)
+        logger.warning("Warning: %s", err)
         return Task("Main")

--- a/tests/test_pickle_save.py
+++ b/tests/test_pickle_save.py
@@ -1,4 +1,5 @@
 import os, sys
+import logging
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 import json
 import builtins
@@ -37,15 +38,15 @@ def test_on_closing_saves_and_loads(tmp_path, monkeypatch):
     assert loaded_sub.completed
 
 
-def test_load_tasks_with_corrupt_json(tmp_path, monkeypatch, capsys):
+def test_load_tasks_with_corrupt_json(tmp_path, monkeypatch, caplog):
     bad_file = tmp_path / 'tasks.json'
     bad_file.write_text('not json', encoding='utf-8')
 
-    task = load_tasks(bad_file)
+    with caplog.at_level(logging.WARNING):
+        task = load_tasks(bad_file)
     assert isinstance(task, Task)
     assert task.name == 'Main'
-    captured = capsys.readouterr()
-    assert 'Warning:' in captured.out
+    assert any('Warning:' in rec.getMessage() for rec in caplog.records)
 
 
 def test_on_closing_no_prompt_when_unmodified(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- replace `print("Warning:", err)` with `logger.warning` in persistence
- update pickle save test to inspect warning logs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ae088d6d08333911465565d6e175d