### PR TITLE
Support nested task CSV round-tripping

### DIFF
--- a/persistence.py
+++ b/persistence.py
@@ -30,25 +30,26 @@ def load_tasks_from_json(path):
         return Task("Main")
 
 
-def _iterate_tasks(task):
-    """Yield ``task`` and all of its subtasks recursively."""
-    yield task
+def _iterate_tasks(task, depth=0):
+    """Yield ``(task, depth)`` for ``task`` and all of its subtasks recursively."""
+    yield task, depth
     for sub in task.get_sub_tasks():
-        yield from _iterate_tasks(sub)
+        yield from _iterate_tasks(sub, depth + 1)
 
 
 def save_tasks_to_csv(task, path):
     """Write the task hierarchy to ``path`` in CSV format."""
     with open(path, "w", newline="", encoding="utf-8") as fh:
         writer = csv.writer(fh)
-        writer.writerow(["Name", "Due Date", "Priority", "Completed"])
-        for t in _iterate_tasks(task):
+        writer.writerow(["Name", "Due Date", "Priority", "Completed", "Depth"])
+        for t, depth in _iterate_tasks(task):
             writer.writerow(
                 [
                     t.name,
                     t.due_date or "",
                     "" if t.priority is None else t.priority,
                     1 if t.completed else 0,
+                    depth,
                 ]
             )
 
@@ -59,7 +60,7 @@ def save_tasks_to_ics(task, path):
         fh.write("BEGIN:VCALENDAR\n")
         fh.write("VERSION:2.0\n")
         fh.write("PRODID:-//Task Manager//EN\n")
-        for t in _iterate_tasks(task):
+        for t, _ in _iterate_tasks(task):
             fh.write("BEGIN:VTODO\n")
             fh.write(f"SUMMARY:{t.name}\n")
             if t.due_date:
@@ -86,22 +87,56 @@ def load_tasks_from_csv(path):
             rows = list(reader)
         if not rows:
             return Task("Main")
-        root_row = rows[0]
-        name, due, prio, completed = root_row[:4]
-        priority = int(prio) if prio else None
-        completed = bool(int(completed)) if completed else False
-        root = Task(name, due_date=due or None, priority=priority, completed=completed)
-        for row in rows[1:]:
+
+        if header and "Depth" in header:
+            depth_index = header.index("Depth")
+        else:
+            depth_index = None
+
+        if depth_index is None:
+            # Legacy format without depth information
+            root_row = rows[0]
+            name, due, prio, completed = root_row[:4]
+            priority = int(prio) if prio else None
+            completed = bool(int(completed)) if completed else False
+            root = Task(name, due_date=due or None, priority=priority, completed=completed)
+            for row in rows[1:]:
+                try:
+                    r_name, r_due, r_prio, r_comp = row[:4]
+                except ValueError:
+                    continue
+                r_priority = int(r_prio) if r_prio else None
+                r_completed = bool(int(r_comp)) if r_comp else False
+                root.add_sub_task(
+                    Task(r_name, due_date=r_due or None, priority=r_priority, completed=r_completed)
+                )
+            return root
+
+        stack = []
+        root = None
+        for row in rows:
             try:
-                r_name, r_due, r_prio, r_comp = row[:4]
-            except ValueError:
+                name, due, prio, comp = row[:4]
+                depth = int(row[depth_index]) if len(row) > depth_index and row[depth_index] != "" else 0
+            except (ValueError, IndexError):
                 continue
-            r_priority = int(r_prio) if r_prio else None
-            r_completed = bool(int(r_comp)) if r_comp else False
-            root.add_sub_task(
-                Task(r_name, due_date=r_due or None, priority=r_priority, completed=r_completed)
-            )
-        return root
+            priority = int(prio) if prio else None
+            completed = bool(int(comp)) if comp else False
+            task = Task(name, due_date=due or None, priority=priority, completed=completed)
+            if depth == 0:
+                root = task
+                stack = [task]
+                continue
+            while len(stack) > depth:
+                stack.pop()
+            parent = stack[-1] if stack else None
+            if parent is None:
+                root = task
+                stack = [task]
+            else:
+                parent.add_sub_task(task)
+                stack.append(task)
+        return root if root is not None else Task("Main")
     except Exception as err:
         logger.warning("Failed to load tasks from %s: %s", path, err)
         print("Warning:", err)

--- a/tests/test_export_formats.py
+++ b/tests/test_export_formats.py
@@ -20,16 +20,26 @@ def build_task_tree():
     return main
 
 
+def build_deep_task_tree():
+    """Return a task tree with multiple nesting levels."""
+    main = build_task_tree()
+    deep = Task("SubSub1")
+    deeper = Task("Deep")
+    deep.add_sub_task(deeper)
+    main.get_sub_tasks()[0].add_sub_task(deep)  # attach under Sub1
+    return main
+
+
 def test_csv_export(tmp_path):
     task = build_task_tree()
     path = tmp_path / 'tasks.csv'
     save_tasks_to_csv(task, path)
     with open(path, newline='', encoding='utf-8') as fh:
         rows = list(csv.reader(fh))
-    assert rows[0] == ['Name', 'Due Date', 'Priority', 'Completed']
-    assert rows[1] == ['Main', '2025-12-31', '1', '0']
-    assert rows[2] == ['Sub1', '', '', '1']
-    assert rows[3] == ['Sub2', '2026-01-01', '', '0']
+    assert rows[0] == ['Name', 'Due Date', 'Priority', 'Completed', 'Depth']
+    assert rows[1] == ['Main', '2025-12-31', '1', '0', '0']
+    assert rows[2] == ['Sub1', '', '', '1', '1']
+    assert rows[3] == ['Sub2', '2026-01-01', '', '0', '1']
 
 
 def test_ics_export(tmp_path):
@@ -56,6 +66,15 @@ def test_csv_round_trip(tmp_path):
     assert loaded.due_date == '2025-12-31'
     assert loaded.priority == 1
     assert loaded.get_sub_tasks()[0].completed
+
+
+def test_csv_round_trip_nested(tmp_path):
+    """A tree with nested subtasks should round-trip through CSV."""
+    task = build_deep_task_tree()
+    path = tmp_path / "nested.csv"
+    save_tasks_to_csv(task, path)
+    loaded = load_tasks_from_csv(path)
+    assert loaded.to_dict() == task.to_dict()
 
 
 def test_ics_round_trip(tmp_path):


### PR DESCRIPTION
## Summary
- include a depth column when exporting to CSV
- parse the depth column when loading CSV files to rebuild the full hierarchy
- test CSV export and import with nested tasks

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ae08756688333a8661d7ba6738b6c