### PR TITLE
Fix theme list to include active theme

### DIFF
--- a/tests/test_window.py
+++ b/tests/test_window.py
@@ -725,12 +725,12 @@ def test_view_menu_themes(monkeypatch):
         if label == "View":
             view_menu = menu
     assert view_menu is not None
-    assert [lbl for lbl, _ in view_menu.commands] == ["light", "dark"]
+    assert [lbl for lbl, _ in view_menu.commands] == ["clam", "light", "dark"]
 
     called = {}
     monkeypatch.setattr(win, "use_theme", lambda t: called.setdefault("theme", t))
-    # trigger second theme command
-    view_menu.commands[1][1]()
+    # trigger third menu command ("dark" theme)
+    view_menu.commands[2][1]()
     assert called.get("theme") == "dark"
 
 

--- a/window.py
+++ b/window.py
@@ -210,7 +210,11 @@ class Window:
             menubar.add_cascade(label="Edit", menu=edit_menu)
 
             view_menu = tk.Menu(menubar, tearoff=0)
-            for theme in self.style.theme_names():
+            theme_names = list(self.style.theme_names())
+            current = self.style.theme_use()
+            if current not in theme_names:
+                theme_names.insert(0, current)
+            for theme in theme_names:
                 view_menu.add_command(
                     label=theme, command=lambda t=theme: self.use_theme(t)
                 )


### PR DESCRIPTION
## Summary
- ensure the current theme is present in the View menu
- adjust tests for updated theme menu behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ae2d60818833399dab498d37624c1