### PR TITLE
Improve JSON loading validation

### DIFF
--- a/persistence.py
+++ b/persistence.py
@@ -23,6 +23,9 @@ def load_tasks_from_json(path):
     try:
         with open(path, "r", encoding="utf-8") as fh:
             data = json.load(fh)
+        if not isinstance(data, dict):
+            logger.warning("Invalid JSON structure in %s: expected mapping", path)
+            return Task("Main")
         return Task.from_dict(data)
     except (FileNotFoundError, json.JSONDecodeError, OSError, TypeError) as err:
         logger.warning("Failed to load tasks from %s: %s", path, err)

--- a/tests/test_json_persistence.py
+++ b/tests/test_json_persistence.py
@@ -72,3 +72,16 @@ def test_load_without_name_field(tmp_path):
     assert isinstance(task, Task)
     assert task.name == 'Unnamed'
 
+
+def test_load_tasks_with_json_array(tmp_path, caplog):
+    """A JSON array should be treated as invalid input."""
+    path = tmp_path / 'array.json'
+    path.write_text('[1, 2, 3]', encoding='utf-8')
+
+    with caplog.at_level(logging.WARNING):
+        task = load_tasks_from_json(path)
+
+    assert isinstance(task, Task)
+    assert task.name == 'Main'
+    assert any('Invalid JSON structure' in rec.getMessage() for rec in caplog.records)
+


### PR DESCRIPTION
## Summary
- validate JSON data structure when loading tasks
- test `load_tasks_from_json` when JSON contains an array

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ae540944083338b9fb6408dd25354