### PR TITLE
Fix theme selection test to support bootstrap

### DIFF
--- a/tests/test_window.py
+++ b/tests/test_window.py
@@ -725,7 +725,8 @@ def test_view_menu_themes(monkeypatch):
         if label == "View":
             view_menu = menu
     assert view_menu is not None
-    assert [lbl for lbl, _ in view_menu.commands] == ["clam", "light", "dark"]
+    expected_default = "flatly" if window.USE_BOOTSTRAP else "clam"
+    assert [lbl for lbl, _ in view_menu.commands] == [expected_default, "light", "dark"]
 
     called = {}
     monkeypatch.setattr(win, "use_theme", lambda t: called.setdefault("theme", t))


### PR DESCRIPTION
## Summary
- fix expected theme in `test_view_menu_themes`

## Testing
- `pytest -q`
- `pip install ttkbootstrap` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_687ae77d5be08333bb0e6ea83b7834af