### PR TITLE
Add task reordering support

### DIFF
--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -88,3 +88,23 @@ def test_undo_and_redo_edit():
     assert c.get_sub_tasks()[0].name == 'A'
     c.redo()
     assert c.get_sub_tasks()[0].name == 'B'
+
+
+def test_move_task_changes_order():
+    c = create_controller()
+    c.add_task('A')
+    c.add_task('B')
+    c.add_task('C')
+    c.move_task(0, 2)
+    assert [t.name for t in c.get_sub_tasks()] == ['B', 'C', 'A']
+
+
+def test_undo_redo_move(monkeypatch=None):
+    c = create_controller()
+    c.add_task('A')
+    c.add_task('B')
+    c.move_task(0, 1)
+    c.undo()
+    assert [t.name for t in c.get_sub_tasks()] == ['A', 'B']
+    c.redo()
+    assert [t.name for t in c.get_sub_tasks()] == ['B', 'A']

--- a/tests/test_window.py
+++ b/tests/test_window.py
@@ -493,6 +493,31 @@ def test_sort_by_due_date(monkeypatch):
     assert [item.split()[0] for item in win.tree.items] == ["Sooner", "Later", "NoDue"]
 
 
+def test_move_selected_up(monkeypatch):
+    win = setup_window(monkeypatch)
+    win.controller.add_task("A")
+    win.controller.add_task("B")
+    win.controller.add_task("C")
+    win.refresh_window()
+    iid = win.tree.get_children()[1]
+    win.tree.selection_set(iid)
+    win.move_selected_up()
+    assert [t.name for t in win.controller.get_sub_tasks()] == ["B", "A", "C"]
+    assert [item.split()[0] for item in win.tree.items] == ["B", "A", "C"]
+
+
+def test_move_selected_down(monkeypatch):
+    win = setup_window(monkeypatch)
+    win.controller.add_task("A")
+    win.controller.add_task("B")
+    win.refresh_window()
+    iid = win.tree.get_children()[0]
+    win.tree.selection_set(iid)
+    win.move_selected_down()
+    assert [t.name for t in win.controller.get_sub_tasks()] == ["B", "A"]
+    assert [item.split()[0] for item in win.tree.items] == ["B", "A"]
+
+
 def test_search_filter(monkeypatch):
     win = setup_window(monkeypatch)
     win.controller.add_task("Hello")

--- a/window.py
+++ b/window.py
@@ -315,6 +315,23 @@ class Window:
         )
         dlt_btn.grid(row=3, column=2, sticky="ew", padx=2)
 
+        btn_opts = {"bootstyle": "secondary"} if USE_BOOTSTRAP else {}
+        up_btn = ttk.Button(
+            self.main_frame,
+            text="Move Up",
+            command=self.move_selected_up,
+            **btn_opts,
+        )
+        up_btn.grid(row=3, column=3, sticky="ew", padx=2)
+
+        down_btn = ttk.Button(
+            self.main_frame,
+            text="Move Down",
+            command=self.move_selected_down,
+            **btn_opts,
+        )
+        down_btn.grid(row=3, column=4, sticky="ew", padx=2)
+
         # --- Filtering widgets ---
         self.search_var = tk.StringVar()
         self.hide_completed_var = tk.IntVar()
@@ -635,6 +652,56 @@ class Window:
     def sort_tasks_by_due_date(self):
         """Sort tasks by due date using the controller and refresh the view."""
         self.controller.sort_tasks_by_due_date()
+        self.refresh_window()
+        if self.parent_window is not None:
+            self.parent_window.refresh_window()
+
+    def move_selected_up(self):
+        """Move the selected task up in the list."""
+        sel = self.tree.selection()
+        if not sel:
+            return
+        item = sel[0]
+        task, parent = self.tree_items.get(item, (None, None))
+        if task is None:
+            return
+        if parent is None:
+            lst = self.controller.get_sub_tasks()
+            idx = lst.index(task)
+            if idx == 0:
+                return
+            self.controller.move_task(idx, idx - 1)
+        else:
+            lst = parent.get_sub_tasks()
+            idx = lst.index(task)
+            if idx == 0:
+                return
+            lst.insert(idx - 1, lst.pop(idx))
+        self.refresh_window()
+        if self.parent_window is not None:
+            self.parent_window.refresh_window()
+
+    def move_selected_down(self):
+        """Move the selected task down in the list."""
+        sel = self.tree.selection()
+        if not sel:
+            return
+        item = sel[0]
+        task, parent = self.tree_items.get(item, (None, None))
+        if task is None:
+            return
+        if parent is None:
+            lst = self.controller.get_sub_tasks()
+            idx = lst.index(task)
+            if idx >= len(lst) - 1:
+                return
+            self.controller.move_task(idx, idx + 1)
+        else:
+            lst = parent.get_sub_tasks()
+            idx = lst.index(task)
+            if idx >= len(lst) - 1:
+                return
+            lst.insert(idx + 1, lst.pop(idx))
         self.refresh_window()
         if self.parent_window is not None:
             self.parent_window.refresh_window()


### PR DESCRIPTION
## Summary
- allow moving tasks within `TaskController`
- expose move up/down buttons in `Window`
- add tests for controller reordering and GUI controls

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687aeafd5834833392eff8cad1cb3e94