### PR TITLE
Add context menu and task reordering

### DIFF
--- a/controller.py
+++ b/controller.py
@@ -136,7 +136,12 @@ class TaskController:
         self._redo_stack.clear()
 
     def move_task(self, from_index, to_index):
-        """Move a task from ``from_index`` to ``to_index``."""
+        """Move a task from ``from_index`` to ``to_index``.
+
+        ``to_index`` may be equal to ``len(sub_tasks)`` to move the item to the
+        end of the list.  ``InvalidTaskIndexError`` is raised if either index is
+        out of range.
+        """
         sub_tasks = self.get_sub_tasks()
         if not 0 <= from_index < len(sub_tasks):
             raise InvalidTaskIndexError(from_index)
@@ -200,8 +205,10 @@ class TaskController:
         if op_type == "move":
             from_idx, to_idx = operation[1], operation[2]
             sub_tasks = self.get_sub_tasks()
-            if not 0 <= from_idx < len(sub_tasks) or not 0 <= to_idx <= len(sub_tasks):
+            if not 0 <= from_idx < len(sub_tasks):
                 raise InvalidTaskIndexError(from_idx)
+            if not 0 <= to_idx <= len(sub_tasks):
+                raise InvalidTaskIndexError(to_idx)
             task = sub_tasks.pop(from_idx)
             sub_tasks.insert(to_idx, task)
             return ("move", to_idx, from_idx)

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -88,3 +88,16 @@ def test_undo_and_redo_edit():
     assert c.get_sub_tasks()[0].name == 'A'
     c.redo()
     assert c.get_sub_tasks()[0].name == 'B'
+
+
+def test_move_task_and_undo_redo():
+    c = create_controller()
+    c.add_task('A')
+    c.add_task('B')
+    c.add_task('C')
+    c.move_task(0, 2)
+    assert [t.name for t in c.get_sub_tasks()] == ['B', 'C', 'A']
+    c.undo()
+    assert [t.name for t in c.get_sub_tasks()] == ['A', 'B', 'C']
+    c.redo()
+    assert [t.name for t in c.get_sub_tasks()] == ['B', 'C', 'A']

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -69,6 +69,12 @@ def test_invalid_index_operations():
         c.delete_task(2)
     with pytest.raises(InvalidTaskIndexError):
         c.mark_task_completed(-1)
+    # moving with an invalid from_index
+    with pytest.raises(InvalidTaskIndexError):
+        c.move_task(1, 0)
+    # moving with an invalid to_index
+    with pytest.raises(InvalidTaskIndexError):
+        c.move_task(0, 2)
 
 
 def test_undo_and_redo_add():

--- a/tests/test_window.py
+++ b/tests/test_window.py
@@ -121,6 +121,10 @@ class DummyTreeview(DummyWidget):
         else:
             self._selection = (iid,)
 
+    def identify_row(self, y):
+        # Return the first item for simplicity
+        return self.get_children()[0] if self.nodes else ""
+
     def bind(self, event, func):
         self.bindings[event] = func
 
@@ -218,6 +222,12 @@ class DummyMenu:
 
     def add_cascade(self, label=None, menu=None):
         self.cascades.append((label, menu))
+
+    def add_separator(self):
+        self.commands.append(("separator", None))
+
+    def tk_popup(self, x, y):
+        self.popup_at = (x, y)
 
 
 class DummyRootWithConfig(DummyRoot):
@@ -561,20 +571,24 @@ def test_double_click_opens_subtasks(monkeypatch):
     assert called.get("view")
 
 
-def test_right_click_calls_toggle(monkeypatch):
+def test_right_click_calls_menu(monkeypatch):
     called = {}
 
-    def fake_toggle(self):
-        called["toggle"] = True
+    def fake_menu(self, event=None):
+        called["menu"] = True
 
-    monkeypatch.setattr(window.Window, "toggle_completion", fake_toggle)
+    monkeypatch.setattr(window.Window, "_show_tree_menu", fake_menu)
     win = setup_window(monkeypatch)
     win.controller.add_task("A")
     win.refresh_window()
     bound = win.tree.bindings.get("<Button-3>")
     assert bound is not None
-    bound(None)
-    assert called.get("toggle")
+    class E:
+        x_root = 0
+        y_root = 0
+        y = 0
+    bound(E())
+    assert called.get("menu")
 
 
 def test_toggle_completion(monkeypatch):
@@ -807,3 +821,15 @@ def test_refresh_preserves_tree_expansion(monkeypatch):
     win.refresh_window()
     parent_id = win.tree.get_children()[0]
     assert win.tree.item(parent_id, "open") is True
+
+
+def test_move_selected_task(monkeypatch):
+    win = setup_window(monkeypatch)
+    win.controller.add_task("A")
+    win.controller.add_task("B")
+    win.refresh_window()
+    items = win.tree.get_children()
+    win.tree.selection_set(items[1])
+    win.move_selected_task(-1)
+    assert [t.name for t in win.controller.get_sub_tasks()] == ["B", "A"]
+    assert [win.tree.nodes[i]["text"].split()[0] for i in win.tree.get_children()] == ["B", "A"]


### PR DESCRIPTION
## Summary
- add right-click context menu for tree view tasks
- implement moving tasks within `TaskController` and `Window`
- bind right-click to the context menu
- expand dummy classes and tests for new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687aeb050da08333858fa9653db65d9b