### PR TITLE
Add completed-only filter

### DIFF
--- a/tests/test_window.py
+++ b/tests/test_window.py
@@ -513,6 +513,16 @@ def test_hide_completed(monkeypatch):
     assert [item.split()[0] for item in win.tree.items] == ["Todo"]
 
 
+def test_show_completed_only(monkeypatch):
+    win = setup_window(monkeypatch)
+    win.controller.add_task("Done")
+    win.controller.add_task("Todo")
+    win.controller.mark_task_completed(0)
+    win.show_completed_only_var.set(1)
+    win.refresh_window()
+    assert [item.split()[0] for item in win.tree.items] == ["Done"]
+
+
 def test_hide_checkbox_triggers_refresh(monkeypatch):
     created = {}
 

--- a/window.py
+++ b/window.py
@@ -318,6 +318,7 @@ class Window:
         # --- Filtering widgets ---
         self.search_var = tk.StringVar()
         self.hide_completed_var = tk.IntVar()
+        self.show_completed_only_var = tk.IntVar()
 
         search_entry = ttk.Entry(self.main_frame, textvariable=self.search_var)
         search_entry.grid(row=4, column=0, sticky="ew", padx=2)
@@ -330,6 +331,14 @@ class Window:
         )
         hide_check.grid(row=4, column=1, sticky="ew", padx=2)
 
+        show_only_check = tk.Checkbutton(
+            self.main_frame,
+            text="Show completed only",
+            variable=self.show_completed_only_var,
+            command=self.refresh_window,
+        )
+        show_only_check.grid(row=4, column=2, sticky="ew", padx=2)
+
         btn_opts = {"bootstyle": "primary"} if USE_BOOTSTRAP else {}
         filter_btn = ttk.Button(
             self.main_frame,
@@ -337,7 +346,7 @@ class Window:
             command=self.refresh_window,
             **btn_opts,
         )
-        filter_btn.grid(row=4, column=2, sticky="ew", padx=2)
+        filter_btn.grid(row=4, column=3, sticky="ew", padx=2)
 
         # Additional filtering controls
         self.due_filter_var = tk.StringVar()
@@ -785,6 +794,7 @@ class Window:
         task,
         search_term="",
         hide_completed=False,
+        show_completed_only=False,
         due_value="",
         before=False,
         after=False,
@@ -794,6 +804,9 @@ class Window:
     ):
         """Return True if ``task`` should be shown with the current filters."""
         if not isinstance(task, Task):
+            return False
+
+        if show_completed_only and not task.completed:
             return False
 
         if hide_completed and task.completed:
@@ -868,6 +881,7 @@ class Window:
         parent_task=None,
         search_term="",
         hide_completed=False,
+        show_completed_only=False,
         due_value="",
         before=False,
         after=False,
@@ -880,6 +894,7 @@ class Window:
             task,
             search_term=search_term,
             hide_completed=hide_completed,
+            show_completed_only=show_completed_only,
             due_value=due_value,
             before=before,
             after=after,
@@ -901,6 +916,7 @@ class Window:
                 task,
                 search_term,
                 hide_completed,
+                show_completed_only,
                 due_value,
                 before,
                 after,
@@ -938,6 +954,11 @@ class Window:
             if hasattr(self, "hide_completed_var")
             else False
         )
+        show_completed_only = (
+            bool(self.show_completed_only_var.get())
+            if hasattr(self, "show_completed_only_var")
+            else False
+        )
         due_value = (
             self.due_filter_var.get().strip() if hasattr(self, "due_filter_var") else ""
         )
@@ -972,6 +993,7 @@ class Window:
                 None,
                 search_term=search_term,
                 hide_completed=hide_completed,
+                show_completed_only=show_completed_only,
                 due_value=due_value,
                 before=before,
                 after=after,


### PR DESCRIPTION
## Summary
- enable showing only completed tasks
- add show only completed checkbox to GUI
- support filtering for completed-only in `_task_visible`
- cover completed-only filter in window tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687aeb0b180c83338dfd9ad0c767dc96