### PR TITLE
Implement auto-save after task updates

### DIFF
--- a/controller.py
+++ b/controller.py
@@ -8,7 +8,10 @@ Usage:
     This module provides the TaskController class for managing tasks in a to-do list.
     It can be used to add, edit, delete tasks, and retrieve task information.
 """
+from pathlib import Path
+
 from task import Task
+import persistence
 
 
 class InvalidTaskIndexError(IndexError):
@@ -32,14 +35,17 @@ class TaskController:
         sort_tasks_by_priority: Sort tasks by their priority value.
     """
 
-    def __init__(self, task):
+    def __init__(self, task, save_path=None):
         """
         Initializes a new TaskController object.
 
         Args:
             task (Task): The main task managed by the controller.
+            save_path (str or Path, optional): Path used for automatic JSON
+                persistence.  If ``None`` (default), auto-saving is disabled.
         """
         self.task = task
+        self.save_path = Path(save_path) if save_path is not None else None
         # Stacks used to store undo and redo operations.  Each entry is a
         # tuple describing the operation that should be executed when popped.
         #
@@ -49,6 +55,15 @@ class TaskController:
         #   ('setattr', index, values)  -> set attributes on task ``index``
         self._undo_stack = []
         self._redo_stack = []
+
+    # ------------------------------------------------------------------
+    def _auto_save(self):
+        """Write current tasks to :pyattr:`save_path` if configured."""
+        if self.save_path is not None:
+            try:
+                persistence.save_tasks_to_json(self.task, self.save_path)
+            except Exception:
+                pass
 
     def add_task(self, task_name, due_date=None, priority=None):
         """
@@ -62,6 +77,7 @@ class TaskController:
         idx = len(self.task.sub_tasks) - 1
         self._undo_stack.append(("delete", idx, new_task))
         self._redo_stack.clear()
+        self._auto_save()
 
     def edit_task(self, task_index, new_name):
         """
@@ -78,6 +94,7 @@ class TaskController:
         sub_tasks[task_index].name = new_name
         self._undo_stack.append(("setattr", task_index, {"name": old_name}))
         self._redo_stack.clear()
+        self._auto_save()
 
     def delete_task(self, index):
         """
@@ -93,6 +110,7 @@ class TaskController:
         self.task.remove_sub_task(removed)
         self._undo_stack.append(("add", index, removed))
         self._redo_stack.clear()
+        self._auto_save()
 
     def mark_task_completed(self, index):
         """Mark the task at the given index as completed."""
@@ -103,6 +121,7 @@ class TaskController:
         sub_tasks[index].mark_completed()
         self._undo_stack.append(("setattr", index, {"completed": prev}))
         self._redo_stack.clear()
+        self._auto_save()
 
     def mark_task_incomplete(self, index):
         """Mark the task at the given index as not completed."""
@@ -113,6 +132,7 @@ class TaskController:
         sub_tasks[index].mark_incomplete()
         self._undo_stack.append(("setattr", index, {"completed": prev}))
         self._redo_stack.clear()
+        self._auto_save()
 
     def set_task_due_date(self, index, due_date):
         """Set the due date for a task at the given index."""
@@ -123,6 +143,7 @@ class TaskController:
         sub_tasks[index].set_due_date(due_date)
         self._undo_stack.append(("setattr", index, {"due_date": prev}))
         self._redo_stack.clear()
+        self._auto_save()
 
     def set_task_priority(self, index, priority):
         """Set the priority for a task at the given index."""
@@ -133,6 +154,7 @@ class TaskController:
         sub_tasks[index].set_priority(priority)
         self._undo_stack.append(("setattr", index, {"priority": prev}))
         self._redo_stack.clear()
+        self._auto_save()
 
     def get_task_name(self):
         """
@@ -155,10 +177,12 @@ class TaskController:
     def sort_tasks_by_priority(self):
         """Sort the controller's sub tasks by priority (None values last)."""
         self.task.sub_tasks.sort(key=lambda t: (t.priority is None, t.priority))
+        self._auto_save()
 
     def sort_tasks_by_due_date(self):
         """Sort the controller's sub tasks by due date (None values last)."""
         self.task.sub_tasks.sort(key=lambda t: (t.due_date is None, t.due_date))
+        self._auto_save()
 
     # --- Undo/Redo support -------------------------------------------------
 
@@ -194,6 +218,7 @@ class TaskController:
         inverse = self._apply_operation(op)
         if inverse:
             self._redo_stack.append(inverse)
+        self._auto_save()
 
     def redo(self):
         """Redo the most recently undone operation, if any."""
@@ -203,3 +228,4 @@ class TaskController:
         inverse = self._apply_operation(op)
         if inverse:
             self._undo_stack.append(inverse)
+        self._auto_save()

--- a/orga.py
+++ b/orga.py
@@ -98,7 +98,7 @@ if __name__ == "__main__":
 
     main_tasks = load_tasks(file_path)
 
-    controller = TaskController(main_tasks)
+    controller = TaskController(main_tasks, save_path=file_path)
     window = Window(root, controller)
     root.protocol("WM_DELETE_WINDOW", lambda: on_closing(main_tasks, root, file_path))
     root.mainloop()

--- a/tests/test_autosave.py
+++ b/tests/test_autosave.py
@@ -1,0 +1,20 @@
+import os, sys
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+import persistence
+from controller import TaskController
+from task import Task
+
+
+def test_add_task_autosaves(tmp_path, monkeypatch):
+    path = tmp_path / "tasks.json"
+    called = {}
+
+    def fake_save(task, file_path):
+        called['task'] = task
+        called['path'] = file_path
+
+    monkeypatch.setattr(persistence, "save_tasks_to_json", fake_save)
+    controller = TaskController(Task("Main"), save_path=path)
+    controller.add_task("A")
+    assert called['task'] is controller.task
+    assert called['path'] == path

--- a/window.py
+++ b/window.py
@@ -166,6 +166,8 @@ class Window:
         self.root = root
         self.task_list = controller.get_sub_tasks()
         self.controller = controller
+        # Expose current save path for convenience
+        self.file_path = controller.save_path
         self.parent_window = parent_window
         self.name = controller.get_task_name()
 


### PR DESCRIPTION
## Summary
- add automatic JSON saving to `TaskController` modifying operations
- store optional `save_path` in controller and expose it on `Window`
- pass file path from `orga.py` when creating controller
- test that auto-save is triggered

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687aeb22e3448333a9a73741d192547a