### PR TITLE
Handle invalid due date filter

### DIFF
--- a/tests/test_window.py
+++ b/tests/test_window.py
@@ -664,6 +664,16 @@ def test_due_date_filter_after(monkeypatch):
     assert [item.split()[0] for item in win.tree.items] == ["Later"]
 
 
+def test_due_date_filter_invalid_input(monkeypatch):
+    win = setup_window(monkeypatch)
+    win.controller.add_task("Soon", due_date="2024-01-01")
+    win.controller.add_task("Later", due_date="2026-01-01")
+    win.due_filter_var.set("invalid")
+    win.due_before_var.set(1)
+    win.refresh_window()
+    assert [item.split()[0] for item in win.tree.items] == ["Soon", "Later"]
+
+
 def test_priority_filter_above(monkeypatch):
     win = setup_window(monkeypatch)
     win.controller.add_task("Low", priority=5)

--- a/window.py
+++ b/window.py
@@ -805,6 +805,11 @@ class Window:
         if due_value and (before or after):
             try:
                 fdate = _datetime.date.fromisoformat(due_value)
+            except ValueError:
+                # Invalid user input - skip due date filtering entirely
+                return True
+
+            try:
                 tdate = (
                     _datetime.date.fromisoformat(str(task.due_date))
                     if getattr(task, "due_date", None)


### PR DESCRIPTION
## Summary
- validate date parsing for due date filtering
- test that invalid due dates do not filter out tasks

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687aeb49d71c8333a65eaef92b34aeec