### PR TITLE
Fix duplicate warning logs in loaders

### DIFF
--- a/persistence.py
+++ b/persistence.py
@@ -29,7 +29,6 @@ def load_tasks_from_json(path):
         return Task.from_dict(data)
     except (FileNotFoundError, json.JSONDecodeError, OSError, TypeError) as err:
         logger.warning("Failed to load tasks from %s: %s", path, err)
-        logger.warning("Warning: %s", err)
         return Task("Main")
 
 
@@ -160,7 +159,6 @@ def load_tasks_from_csv(path):
             return root if root is not None else Task("Main")
     except Exception as err:
         logger.warning("Failed to load tasks from %s: %s", path, err)
-        logger.warning("Warning: %s", err)
         return Task("Main")
 
 
@@ -208,5 +206,4 @@ def load_tasks_from_ics(path):
         return root
     except Exception as err:
         logger.warning("Failed to load tasks from %s: %s", path, err)
-        logger.warning("Warning: %s", err)
         return Task("Main")

--- a/tests/test_pickle_save.py
+++ b/tests/test_pickle_save.py
@@ -46,7 +46,7 @@ def test_load_tasks_with_corrupt_json(tmp_path, monkeypatch, caplog):
         task = load_tasks(bad_file)
     assert isinstance(task, Task)
     assert task.name == 'Main'
-    assert any('Warning:' in rec.getMessage() for rec in caplog.records)
+    assert any('Failed to load tasks' in rec.getMessage() for rec in caplog.records)
 
 
 def test_on_closing_no_prompt_when_unmodified(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- log a single warning when loader functions fail
- adjust failing test to match new log message

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687aeb5ac7608333b7ec6c9cce14a678