### PR TITLE
Remove sys.path hacks in tests

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,16 @@
+from importlib import util
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+
+def load_module(name: str):
+    """Load a module from the project root without modifying sys.path."""
+    if name in sys.modules:
+        return sys.modules[name]
+    module_path = ROOT / f"{name}.py"
+    spec = util.spec_from_file_location(name, module_path)
+    module = util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -1,8 +1,11 @@
-import os, sys
 import pytest
-sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
-from task import Task
-from controller import TaskController, InvalidTaskIndexError
+from helpers import load_module
+
+task = load_module("task")
+controller_mod = load_module("controller")
+Task = task.Task
+TaskController = controller_mod.TaskController
+InvalidTaskIndexError = controller_mod.InvalidTaskIndexError
 
 
 def create_controller():

--- a/tests/test_export_formats.py
+++ b/tests/test_export_formats.py
@@ -1,14 +1,13 @@
-import os, sys
 import csv
+from helpers import load_module
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
-from task import Task
-from persistence import (
-    save_tasks_to_csv,
-    save_tasks_to_ics,
-    load_tasks_from_csv,
-    load_tasks_from_ics,
-)
+task = load_module("task")
+persistence_mod = load_module("persistence")
+Task = task.Task
+save_tasks_to_csv = persistence_mod.save_tasks_to_csv
+save_tasks_to_ics = persistence_mod.save_tasks_to_ics
+load_tasks_from_csv = persistence_mod.load_tasks_from_csv
+load_tasks_from_ics = persistence_mod.load_tasks_from_ics
 
 
 def build_task_tree():

--- a/tests/test_json_persistence.py
+++ b/tests/test_json_persistence.py
@@ -1,9 +1,12 @@
-import os, sys
 import pytest
 import logging
-sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
-from task import Task
-from persistence import save_tasks_to_json, load_tasks_from_json
+from helpers import load_module
+
+task = load_module("task")
+persistence_mod = load_module("persistence")
+Task = task.Task
+save_tasks_to_json = persistence_mod.save_tasks_to_json
+load_tasks_from_json = persistence_mod.load_tasks_from_json
 
 
 def build_task_tree():

--- a/tests/test_pickle_save.py
+++ b/tests/test_pickle_save.py
@@ -1,12 +1,19 @@
-import os, sys
 import logging
-sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
-import json
 import builtins
 from pathlib import Path
-from task import Task
-from orga import on_closing, load_tasks, tkMessageBox
-from persistence import load_tasks_from_json, save_tasks_to_json
+from helpers import load_module
+
+task = load_module("task")
+_ = load_module("window")
+orga_mod = load_module("orga")
+persistence_mod = load_module("persistence")
+
+Task = task.Task
+on_closing = orga_mod.on_closing
+load_tasks = orga_mod.load_tasks
+tkMessageBox = orga_mod.tkMessageBox
+load_tasks_from_json = persistence_mod.load_tasks_from_json
+save_tasks_to_json = persistence_mod.save_tasks_to_json
 
 
 def test_on_closing_saves_and_loads(tmp_path, monkeypatch):

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -1,7 +1,7 @@
-import os, sys
-sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 import pytest
-from task import Task
+from helpers import load_module
+
+Task = load_module("task").Task
 
 
 def test_task_str_without_subtasks():

--- a/tests/test_window.py
+++ b/tests/test_window.py
@@ -1,9 +1,10 @@
-import os, sys
+from helpers import load_module
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
-from task import Task
-from controller import TaskController
-import window
+task = load_module("task")
+controller_mod = load_module("controller")
+window = load_module("window")
+Task = task.Task
+TaskController = controller_mod.TaskController
 import datetime
 
 


### PR DESCRIPTION
## Summary
- remove path modifications from tests
- add `tests/helpers.py` to load modules directly
- adjust imports in each test file to use the helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687aeb60103c8333bfe2ad0433e9c94f