### PR TITLE
Add autosave for move_task and test

### DIFF
--- a/controller.py
+++ b/controller.py
@@ -187,6 +187,7 @@ class TaskController:
         sub_tasks.insert(to_index, task)
         self._undo_stack.append(("move", to_index, from_index))
         self._redo_stack.clear()
+        self._auto_save()
 
     def get_task_name(self):
         """

--- a/tests/test_autosave.py
+++ b/tests/test_autosave.py
@@ -18,3 +18,21 @@ def test_add_task_autosaves(tmp_path, monkeypatch):
     controller.add_task("A")
     assert called['task'] is controller.task
     assert called['path'] == path
+
+
+def test_move_task_autosaves(tmp_path, monkeypatch):
+    path = tmp_path / "tasks.json"
+    controller = TaskController(Task("Main"), save_path=path)
+    controller.add_task("A")
+    controller.add_task("B")
+
+    called = {}
+
+    def fake_save(task, file_path):
+        called['task'] = task
+        called['path'] = file_path
+
+    monkeypatch.setattr(persistence, "save_tasks_to_json", fake_save)
+    controller.move_task(0, 1)
+    assert called['task'] is controller.task
+    assert called['path'] == path


### PR DESCRIPTION
## Summary
- call `_auto_save` when moving a task
- test that moving a task triggers autosave

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687afbf1178c83339197d15331dfaa60