### PR TITLE
Fix bootstrap check with dummy Tk modules

### DIFF
--- a/window.py
+++ b/window.py
@@ -187,8 +187,11 @@ class Window:
         # ttkbootstrap when a real ``tk.Tk`` instance is supplied; otherwise the
         # themed style may try to create its own root window which breaks unit
         # tests that pass in dummy objects.
+        tk_root_type = getattr(tk, "Tk", None)
         bootstrap_ok = (
-            BootstrapStyle is not None and isinstance(self.root, tk.Tk)
+            BootstrapStyle is not None
+            and isinstance(tk_root_type, type)
+            and isinstance(self.root, tk_root_type)
         )
 
         if bootstrap_ok:


### PR DESCRIPTION
## Summary
- avoid AttributeError when tests monkeypatch `tk` module
- ensure `Window` only uses ttkbootstrap when `tk.Tk` is a real class

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687afd1d2e04833389c2c76a7b04675a