### PR TITLE
Add alphabetical task sorting

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ The Task-Manager Application is a simple graphical user interface (GUI) applicat
 - Import and export tasks in CSV, JSON, or ICS formats from the File menu
 - Optional due dates and priority levels for tasks
 - Mark tasks as completed
+- Sort tasks by priority, due date, or name
 - Switch themes from the View menu
 
 ## Color Coding
@@ -49,13 +50,15 @@ The task list uses colors to highlight different states and priorities:
 
 5. **Saving Changes**: The application prompts you to save changes when you close the window. Click "Yes" to save changes or "No" to discard them.
 
-6. **Filtering Tasks**: Use the controls below the task list to filter. You can
+6. **Sorting Tasks**: Use the "Sort by Priority", "Sort by Due Date", or "Sort by Name" buttons to reorder the list.
+
+7. **Filtering Tasks**: Use the controls below the task list to filter. You can
    search by name, hide completed tasks, show only tasks due before or after a
    specific date, and display tasks with priority above or below a chosen
    threshold. Click "Apply Filter" to update the list.
-7. **Changing Themes**: Open the "View" menu and select a theme. When
+8. **Changing Themes**: Open the "View" menu and select a theme. When
    `ttkbootstrap` is installed, additional modern themes become available.
-8. **Import/Export**: Use the "File" menu to export tasks to CSV or ICS or to
+9. **Import/Export**: Use the "File" menu to export tasks to CSV or ICS or to
    import tasks from existing CSV/ICS files.
 
 ## File Structure

--- a/controller.py
+++ b/controller.py
@@ -203,6 +203,11 @@ class TaskController:
         self.task.sub_tasks.sort(key=lambda t: (t.due_date is None, t.due_date))
         self._auto_save()
 
+    def sort_tasks_by_name(self):
+        """Sort the controller's sub tasks alphabetically by name."""
+        self.task.sub_tasks.sort(key=lambda t: t.name.lower())
+        self._auto_save()
+
     # --- Undo/Redo support -------------------------------------------------
 
     def _apply_operation(self, operation):

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -63,6 +63,15 @@ def test_sort_tasks_by_due_date():
     assert [t.name for t in c.get_sub_tasks()] == ['Sooner', 'Later', 'NoDue']
 
 
+def test_sort_tasks_by_name():
+    c = create_controller()
+    c.add_task('b')
+    c.add_task('a')
+    c.add_task('c')
+    c.sort_tasks_by_name()
+    assert [t.name for t in c.get_sub_tasks()] == ['a', 'b', 'c']
+
+
 def test_invalid_index_operations():
     c = create_controller()
     c.add_task('Only')

--- a/tests/test_window.py
+++ b/tests/test_window.py
@@ -505,6 +505,16 @@ def test_sort_by_due_date(monkeypatch):
     assert [item.split()[0] for item in win.tree.items] == ["Sooner", "Later", "NoDue"]
 
 
+def test_sort_by_name(monkeypatch):
+    win = setup_window(monkeypatch)
+    win.controller.add_task("b")
+    win.controller.add_task("a")
+    win.controller.add_task("c")
+    win.sort_tasks_by_name()
+    assert [t.name for t in win.controller.get_sub_tasks()] == ["a", "b", "c"]
+    assert [item.split()[0] for item in win.tree.items] == ["a", "b", "c"]
+
+
 def test_move_selected_up(monkeypatch):
     win = setup_window(monkeypatch)
     win.controller.add_task("A")

--- a/window.py
+++ b/window.py
@@ -294,6 +294,14 @@ class Window:
         )
         sort_due_btn.grid(row=1, column=2, sticky="ew", padx=2)
 
+        sort_name_btn = ttk.Button(
+            self.main_frame,
+            text="Sort by Name",
+            command=self.sort_tasks_by_name,
+            **btn_opts,
+        )
+        sort_name_btn.grid(row=1, column=3, sticky="ew", padx=2)
+
         self.tree = ttk.Treeview(self.main_frame, show="tree")
         self.tree.grid(row=2, column=0, columnspan=3, sticky="nsew", pady=5)
         self.tree_items = {}
@@ -703,6 +711,13 @@ class Window:
     def sort_tasks_by_due_date(self):
         """Sort tasks by due date using the controller and refresh the view."""
         self.controller.sort_tasks_by_due_date()
+        self.refresh_window()
+        if self.parent_window is not None:
+            self.parent_window.refresh_window()
+
+    def sort_tasks_by_name(self):
+        """Sort tasks alphabetically using the controller and refresh the view."""
+        self.controller.sort_tasks_by_name()
         self.refresh_window()
         if self.parent_window is not None:
             self.parent_window.refresh_window()


### PR DESCRIPTION
## Summary
- allow sorting tasks alphabetically in the controller and GUI
- document the sorting feature
- add tests for the new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687afeb61c5083338e76802113f415e5