### PR TITLE
Fix tkcalendar style attribute crash

### DIFF
--- a/tests/test_calendar_patch.py
+++ b/tests/test_calendar_patch.py
@@ -1,0 +1,34 @@
+import types, sys
+from helpers import load_module
+
+class DummyCal:
+    def __init__(self, *args, **kwargs):
+        self.received = {}
+        if kwargs:
+            self.configure(**kwargs)
+
+    def configure(self, **kwargs):
+        for k, v in kwargs.items():
+            self[k] = v
+
+    def __setitem__(self, key, value):
+        raise AttributeError(f"Calendar object has no attribute {key}.")
+
+class DummyDateEntry(DummyCal):
+    pass
+
+
+def test_style_patch_applies(monkeypatch):
+    dummy_module = types.ModuleType("tkcalendar")
+    dummy_module.DateEntry = DummyDateEntry
+    dummy_module.calendar_ = types.SimpleNamespace(Calendar=DummyCal)
+
+    monkeypatch.setitem(sys.modules, "tkcalendar", dummy_module)
+    monkeypatch.setitem(sys.modules, "tkcalendar.calendar_", dummy_module.calendar_)
+
+    monkeypatch.delitem(sys.modules, "window", raising=False)
+    win = load_module("window")
+    assert hasattr(win._TkCalendar, "_bootstrap_patch")
+
+    cal = win._TkCalendar(style="test")
+    assert cal._properties.get("style") == "test"

--- a/window.py
+++ b/window.py
@@ -43,13 +43,24 @@ try:
     # succeeds.
     if _TkCalendar is not None and not hasattr(_TkCalendar, "_bootstrap_patch"):
         _orig_init = _TkCalendar.__init__
+        _orig_setitem = _TkCalendar.__setitem__
 
         def _patched_init(self, *args, **kwargs):
             if not hasattr(self, "_properties"):
                 self._properties = {}
             _orig_init(self, *args, **kwargs)
 
+        def _patched_setitem(self, key, value):
+            try:
+                _orig_setitem(self, key, value)
+            except AttributeError:
+                if key == "style":
+                    self._properties[key] = value
+                else:
+                    raise
+
         _TkCalendar.__init__ = _patched_init
+        _TkCalendar.__setitem__ = _patched_setitem
         _TkCalendar._bootstrap_patch = True
 except ModuleNotFoundError:  # Fallback when tkcalendar is unavailable
 


### PR DESCRIPTION
## Summary
- patch Calendar integration with ttkbootstrap
- test patch using dummy tkcalendar module

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c0debc5a48333ba3631f475521ed1