### PR TITLE
Document Python version compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,22 @@ The task list uses colors to highlight different states and priorities:
 - **Orange**: priority `1` tasks
 - **Yellow**: priority `2` tasks
 
-## Requirements
-- Python 3.7
+- Python 3.8 or later
 - Tkinter (should be included with Python installation; on some Linux
   systems you may need the `python3-tk` package)
 - Additional Python dependencies are listed in `requirements.txt`
   (`tkcalendar` for calendar pop-ups and `ttkbootstrap` for optional
   modern themes)
+
+### Python Compatibility
+The program dynamically chooses whether to use the modern **ttkbootstrap**
+widgets.  On Python&nbsp;≥&nbsp;3.10 any recent version of the library works
+without additional patches.  When running on Python&nbsp;3.8 or 3.9 the
+application tries to import **ttkbootstrap**&nbsp;1.10.x and automatically
+creates the missing ``Date.Toplevel`` style used by ``tkcalendar``.  If a
+newer version of **ttkbootstrap** raises ``TypeError`` during initialisation or
+the library is not available at all, the program falls back to plain ttk so the
+interface still functions (just without the bootstrap styling).
 
 ## Installation
 1. Clone or download the repository to your local machine.

--- a/window.py
+++ b/window.py
@@ -31,7 +31,7 @@ else:
     try:
         import ttkbootstrap as ttkb
         ver = getattr(ttkb, "__version__", "")
-        if ver.startswith("1.10"):
+        if not ver or ver.startswith("1.10"):
             from ttkbootstrap import Style as BootstrapStyle
         else:
             raise TypeError("incompatible ttkbootstrap")

--- a/window.py
+++ b/window.py
@@ -246,35 +246,23 @@ else:
         """Safe DateEntry wrapper to handle early style configuration."""
 
         def __init__(self, *args, **kwargs):
+            style = ttk.Style()
             try:
-                _CalendarDateEntry.__init__(self, *args, **kwargs)
-            except tk.TclError as exc:
-                if "Date.Toplevel" in str(exc):
-                    # The themed ``Date.Toplevel`` style may not exist with
-                    # some combinations of ``tkcalendar`` and ``ttkbootstrap``.
-                    # Create a basic layout derived from ``Toplevel`` (or
-                    # ``TFrame`` if unavailable) and try again.
-                    style = ttk.Style()
+                style.layout("Date.Toplevel")
+            except tk.TclError:
+                try:
+                    base = style.layout("Toplevel")
+                except tk.TclError:
                     try:
-                        style.layout("Date.Toplevel")
-                        missing = False
+                        base = style.layout("TFrame")
                     except tk.TclError:
-                        missing = True
-                    if missing:
-                        try:
-                            base = style.layout("Toplevel")
-                        except tk.TclError:
-                            try:
-                                base = style.layout("TFrame")
-                            except tk.TclError:
-                                base = ""
-                        try:
-                            style.layout("Date.Toplevel", base)
-                        except tk.TclError:
-                            pass
-                    _CalendarDateEntry.__init__(self, *args, **kwargs)
-                else:
-                    raise
+                        base = ""
+                try:
+                    style.layout("Date.Toplevel", base)
+                except tk.TclError:
+                    pass
+
+            _CalendarDateEntry.__init__(self, *args, **kwargs)
 
         def configure(self, *args, **kwargs):
             try:

--- a/window.py
+++ b/window.py
@@ -255,15 +255,23 @@ else:
                     # Create a basic layout derived from ``Toplevel`` (or
                     # ``TFrame`` if unavailable) and try again.
                     style = ttk.Style()
-                    if not style.layout("Date.Toplevel"):
+                    try:
+                        style.layout("Date.Toplevel")
+                        missing = False
+                    except tk.TclError:
+                        missing = True
+                    if missing:
                         try:
                             base = style.layout("Toplevel")
-                        except Exception:
+                        except tk.TclError:
                             try:
                                 base = style.layout("TFrame")
-                            except Exception:
+                            except tk.TclError:
                                 base = ""
-                        style.layout("Date.Toplevel", base)
+                        try:
+                            style.layout("Date.Toplevel", base)
+                        except tk.TclError:
+                            pass
                     _CalendarDateEntry.__init__(self, *args, **kwargs)
                 else:
                     raise

--- a/window.py
+++ b/window.py
@@ -8,19 +8,38 @@ Usage:
     This module provides the Window class for managing the main application window of a to-do list.
 """
 
+import sys
 import tkinter as tk
 import tkinter.ttk as _ttk
 ttk = _ttk  # default ttk module
 
-# Try to load ttkbootstrap for optional theming enhancements.  When available
-# we use its ``Style`` class and widget set so ``bootstyle`` keywords work.
-try:
-    from ttkbootstrap import Style as BootstrapStyle
-    import ttkbootstrap as ttkb
-except Exception:  # Library not installed or failed to load
-    BootstrapStyle = None
-    ttkb = None
+# Try to load ttkbootstrap for optional theming enhancements.  On
+# Python ≥ 3.10 any recent version works.  On Python 3.8/3.9 only the
+# 1.10.x series is compatible; newer releases raise ``TypeError`` when the
+# style class initialises.  If an incompatible or missing version is
+# detected we silently fall back to plain ``ttk``.
+
+BootstrapStyle = None
+ttkb = None
+if sys.version_info >= (3, 10):
+    try:
+        from ttkbootstrap import Style as BootstrapStyle
+        import ttkbootstrap as ttkb
+    except Exception:
+        pass
 else:
+    try:
+        import ttkbootstrap as ttkb
+        ver = getattr(ttkb, "__version__", "")
+        if ver.startswith("1.10"):
+            from ttkbootstrap import Style as BootstrapStyle
+        else:
+            raise TypeError("incompatible ttkbootstrap")
+    except Exception:
+        ttkb = None
+        BootstrapStyle = None
+
+if ttkb is not None:
     ttk = ttkb
     # Provide compatibility shims for older versions of ``ttkbootstrap``
     # that do not implement tkcalendar-specific style builders.  The


### PR DESCRIPTION
## Summary
- clarify Python version requirements in README
- explain how ttkbootstrap falls back on older versions of Python
- handle Python version when using ttkbootstrap

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687ea7a9af84833387ea3e5e1158c99b